### PR TITLE
refactor: Optimize Helm values files for clarity and usability

### DIFF
--- a/opensource-setup/kubernetes/demo-values.yaml
+++ b/opensource-setup/kubernetes/demo-values.yaml
@@ -1,19 +1,20 @@
 global:
   security:
+    # Enable this to allow the Bitnami Chart to use the AutoMQ image.
     allowInsecureImages: true
 image:
   registry: automqinc
   repository: automq
-  tag: 1.5.0-bitnami
+  tag: 1.5.3-rc0-bitnami
   pullPolicy: Always
 controller:
   replicaCount: 3
   resources:
     requests:
-      cpu: "3000m"
+      cpu: "3"
       memory: "12Gi"
     limits:
-      cpu: "4000m"
+      cpu: "4"
       memory: "16Gi"
   heapOpts: -Xmx6g -Xms6g -XX:MaxDirectMemorySize=6g -XX:MetaspaceSize=96m
   extraConfig: |
@@ -26,52 +27,30 @@ controller:
     s3.block.cache.size=1073741824
     s3.stream.allocator.policy=POOLED_DIRECT
     s3.network.baseline.bandwidth=245366784
-    # Replace the following with your bucket config
+    # Replace the following with your bucket config.
     s3.ops.buckets=1@s3://${ops-bucket}?region=${region}&endpoint=${endpoint}
     s3.data.buckets=0@s3://${data-bucket}?region=${region}&endpoint=${endpoint}
     s3.wal.path=0@s3://${data-bucket}?region=${region}&endpoint=${endpoint}
-  affinity:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/instance
-                operator: In
-                # your helm release name
-                values:
-                  - automq-release
-              - key: app.kubernetes.io/component
-                operator: In
-                values:
-                  - controller-eligible
-                  - broker
-          topologyKey: kubernetes.io/hostname
-#    ---     nodeAffinity recommended   ---
-#    nodeAffinity:
-#      requiredDuringSchedulingIgnoredDuringExecution:
-#        nodeSelectorTerms:
-#          - matchExpressions:
-#              - key: "${your-node-label-key}"
-#                operator: In
-#                values:
-#                  - "${your-node-label-value}"
   tolerations:
     - key: "dedicated"
       operator: "Equal"
       value: "automq"
       effect: "NoSchedule"
   persistence:
-    storageClass: "${your-storage-class}"
+    # gp2 is the default storage class in AWS EKS.
+    # If you're using a different storage class, please update it here.
+    # Similar to Apache Kafka, AutoMQ requires a small disk to store metadata.
+    storageClass: "gp2"
     size: 20Gi
 
 broker:
-  replicaCount: 3
+  replicaCount: 1
   resources:
     requests:
-      cpu: "3000m"
+      cpu: "3"
       memory: "12Gi"
     limits:
-      cpu: "4000m"
+      cpu: "4"
       memory: "16Gi"
   heapOpts: -Xmx6g -Xms6g -XX:MaxDirectMemorySize=6g -XX:MetaspaceSize=96m
   extraConfig: |
@@ -84,40 +63,18 @@ broker:
     s3.block.cache.size=1073741824
     s3.stream.allocator.policy=POOLED_DIRECT
     s3.network.baseline.bandwidth=245366784
-    # Replace the following with your bucket config
+    # Replace the following with your bucket config.
     s3.ops.buckets=1@s3://${ops-bucket}?region=${region}&endpoint=${endpoint}
     s3.data.buckets=0@s3://${data-bucket}?region=${region}&endpoint=${endpoint}
     s3.wal.path=0@s3://${data-bucket}?region=${region}&endpoint=${endpoint}
-  affinity:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/instance
-                operator: In
-                # your helm release name
-                values:
-                  - automq-release
-              - key: app.kubernetes.io/component
-                operator: In
-                values:
-                  - controller-eligible
-                  - broker
-          topologyKey: kubernetes.io/hostname
-#    ---     nodeAffinity recommended   ---
-#    nodeAffinity:
-#      requiredDuringSchedulingIgnoredDuringExecution:
-#        nodeSelectorTerms:
-#          - matchExpressions:
-#              - key: "${your-node-label-key}"
-#                operator: In
-#                values:
-#                  - "${your-node-label-value}"
   tolerations:
     - key: "dedicated"
       operator: "Equal"
       value: "automq"
       effect: "NoSchedule"
   persistence:
-    storageClass: "${your-storage-class}"
+    # gp2 is the default storage class in AWS EKS.
+    # If you're using a different storage class, please update it here.
+    # Similar to Apache Kafka, AutoMQ requires a small disk to store metadata.
+    storageClass: "gp2"
     size: 20Gi

--- a/opensource-setup/kubernetes/multi-az/demo-multi-az-values.yaml
+++ b/opensource-setup/kubernetes/multi-az/demo-multi-az-values.yaml
@@ -1,19 +1,20 @@
 global:
   security:
+    # Enable this to allow the Bitnami Chart to use the AutoMQ image.
     allowInsecureImages: true
 image:
   registry: automqinc
   repository: automq
-  tag: 1.5.0-bitnami
+  tag: 1.5.3-rc0-bitnami
   pullPolicy: Always
 controller:
   replicaCount: 3
   resources:
     requests:
-      cpu: "3000m"
+      cpu: "3"
       memory: "12Gi"
     limits:
-      cpu: "4000m"
+      cpu: "4"
       memory: "16Gi"
   heapOpts: -Xmx6g -Xms6g -XX:MaxDirectMemorySize=6g -XX:MetaspaceSize=96m
   extraConfig: |
@@ -26,36 +27,13 @@ controller:
     s3.block.cache.size=1073741824
     s3.stream.allocator.policy=POOLED_DIRECT
     s3.network.baseline.bandwidth=245366784
-    # Replace the following with your bucket config
+    # Replace the following with your bucket config.
     s3.ops.buckets=1@s3://${ops-bucket}?region=${region}&endpoint=${endpoint}
     s3.data.buckets=0@s3://${data-bucket}?region=${region}&endpoint=${endpoint}
     s3.wal.path=0@s3://${data-bucket}?region=${region}&endpoint=${endpoint}
+    # Enable this configuration to allow the zone router to eliminate cross-zone traffic.
+    # Apply it only for AWS and GCP, as other cloud vendors do not charge for cross-zone traffic.
     automq.zonerouter.channels=0@s3://${data-bucket}?region=${region}&endpoint=${endpoint}
-  affinity:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/instance
-                operator: In
-                # your helm release name
-                values:
-                  - automq-release
-              - key: app.kubernetes.io/component
-                operator: In
-                values:
-                  - controller-eligible
-                  - broker
-          topologyKey: kubernetes.io/hostname
-#    ---     nodeAffinity recommended   ---
-#    nodeAffinity:
-#      requiredDuringSchedulingIgnoredDuringExecution:
-#        nodeSelectorTerms:
-#          - matchExpressions:
-#              - key: "${your-node-label-key}"
-#                operator: In
-#                values:
-#                  - "${your-node-label-value}"
   topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: topology.kubernetes.io/zone
@@ -69,17 +47,20 @@ controller:
       value: "automq"
       effect: "NoSchedule"
   persistence:
-    storageClass: "${your-storage-class}"
+    # gp2 is the default storage class in AWS EKS.
+    # If you're using a different storage class, please update it here.
+    # Similar to Apache Kafka, AutoMQ requires a small disk to store metadata.
+    storageClass: "gp2"
     size: 20Gi
 
 broker:
   replicaCount: 3
   resources:
     requests:
-      cpu: "3000m"
+      cpu: "3"
       memory: "12Gi"
     limits:
-      cpu: "4000m"
+      cpu: "4"
       memory: "16Gi"
   heapOpts: -Xmx6g -Xms6g -XX:MaxDirectMemorySize=6g -XX:MetaspaceSize=96m
   extraConfig: |
@@ -92,36 +73,13 @@ broker:
     s3.block.cache.size=1073741824
     s3.stream.allocator.policy=POOLED_DIRECT
     s3.network.baseline.bandwidth=245366784
-    # Replace the following with your bucket config
+    # Replace the following with your bucket config.
     s3.ops.buckets=1@s3://${ops-bucket}?region=${region}&endpoint=${endpoint}
     s3.data.buckets=0@s3://${data-bucket}?region=${region}&endpoint=${endpoint}
     s3.wal.path=0@s3://${data-bucket}?region=${region}&endpoint=${endpoint}
+    # Enable this configuration to allow the zone router to eliminate cross-zone traffic.
+    # Apply it only for AWS and GCP, as other cloud vendors do not charge for cross-zone traffic.
     automq.zonerouter.channels=0@s3://${data-bucket}?region=${region}&endpoint=${endpoint}
-  affinity:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/instance
-                operator: In
-                # your helm release name
-                values:
-                  - automq-release
-              - key: app.kubernetes.io/component
-                operator: In
-                values:
-                  - controller-eligible
-                  - broker
-          topologyKey: kubernetes.io/hostname
-#    ---     nodeAffinity recommended   ---
-#    nodeAffinity:
-#      requiredDuringSchedulingIgnoredDuringExecution:
-#        nodeSelectorTerms:
-#          - matchExpressions:
-#              - key: "${your-node-label-key}"
-#                operator: In
-#                values:
-#                  - "${your-node-label-value}"
   topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: topology.kubernetes.io/zone
@@ -135,6 +93,10 @@ broker:
       value: "automq"
       effect: "NoSchedule"
   persistence:
-    storageClass: "${your-storage-class}"
+    # gp2 is the default storage class in AWS EKS.
+    # If you're using a different storage class, please update it here.
+    # Similar to Apache Kafka, AutoMQ requires a small disk to store metadata.
+    storageClass: "gp2"
     size: 20Gi
+# aws-az and azure are supported here
 brokerRackAssignment: aws-az

--- a/opensource-setup/kubernetes/tls/demo-tls-values.yaml
+++ b/opensource-setup/kubernetes/tls/demo-tls-values.yaml
@@ -1,12 +1,13 @@
 global:
   security:
+    # Enable this to allow the Bitnami Chart to use the AutoMQ image.
     allowInsecureImages: true
 image:
   registry: automqinc
   repository: automq
-  tag: 1.5.0-bitnami
+  tag: 1.5.3-rc0-bitnami
   pullPolicy: Always
-#  ----- mTLS enabled (sslClientAuth: required) -----
+# mTLS enabled (sslClientAuth: required)
 listeners:
   client:
     containerPort: 9092
@@ -20,18 +21,16 @@ tls:
   passwordsSecret: kafka-tls-passwords
   sslClientAuth: "required"
 
-
 controller:
   replicaCount: 3
   resources:
     requests:
-      cpu: "3000m"
+      cpu: "3"
       memory: "12Gi"
     limits:
-      cpu: "4000m"
+      cpu: "4"
       memory: "16Gi"
   heapOpts: -Xmx6g -Xms6g -XX:MaxDirectMemorySize=6g -XX:MetaspaceSize=96m
-  #  ----- when INTERNAL protocol set to SSL, change the autobalancer auth to SSL -----
   extraConfig: |
     elasticstream.enable=true
     autobalancer.client.auth.sasl.mechanism=PLAIN
@@ -42,46 +41,32 @@ controller:
     s3.block.cache.size=1073741824
     s3.stream.allocator.policy=POOLED_DIRECT
     s3.network.baseline.bandwidth=245366784
-    # Replace the following with your bucket config
+    # Replace the following with your bucket config.
     s3.ops.buckets=1@s3://${ops-bucket}?region=${region}&endpoint=${endpoint}
     s3.data.buckets=0@s3://${data-bucket}?region=${region}&endpoint=${endpoint}
     s3.wal.path=0@s3://${data-bucket}?region=${region}&endpoint=${endpoint}
-  affinity:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/instance
-                operator: In
-                # your helm release name
-                values:
-                  - automq-release
-              - key: app.kubernetes.io/component
-                operator: In
-                values:
-                  - controller-eligible
-                  - broker
-          topologyKey: kubernetes.io/hostname
   tolerations:
     - key: "dedicated"
       operator: "Equal"
       value: "automq"
       effect: "NoSchedule"
   persistence:
-    storageClass: "${your-storage-class}"
+    # gp2 is the default storage class in AWS EKS.
+    # If you're using a different storage class, please update it here.
+    # Similar to Apache Kafka, AutoMQ requires a small disk to store metadata.
+    storageClass: "gp2"
     size: 20Gi
 
 broker:
-  replicaCount: 3
+  replicaCount: 1
   resources:
     requests:
-      cpu: "3000m"
+      cpu: "3"
       memory: "12Gi"
     limits:
-      cpu: "4000m"
+      cpu: "4"
       memory: "16Gi"
   heapOpts: -Xmx6g -Xms6g -XX:MaxDirectMemorySize=6g -XX:MetaspaceSize=96m
-  #  ----- when INTERNAL protocol set to SSL, change the autobalancer auth to SSL -----
   extraConfig: |
     elasticstream.enable=true
     autobalancer.client.auth.sasl.mechanism=PLAIN
@@ -92,31 +77,18 @@ broker:
     s3.block.cache.size=1073741824
     s3.stream.allocator.policy=POOLED_DIRECT
     s3.network.baseline.bandwidth=245366784
-    # Replace the following with your bucket config
+    # Replace the following with your bucket config.
     s3.ops.buckets=1@s3://${ops-bucket}?region=${region}&endpoint=${endpoint}
     s3.data.buckets=0@s3://${data-bucket}?region=${region}&endpoint=${endpoint}
     s3.wal.path=0@s3://${data-bucket}?region=${region}&endpoint=${endpoint}
-  affinity:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/instance
-                operator: In
-                # your helm release name
-                values:
-                  - automq-release
-              - key: app.kubernetes.io/component
-                operator: In
-                values:
-                  - controller-eligible
-                  - broker
-          topologyKey: kubernetes.io/hostname
   tolerations:
     - key: "dedicated"
       operator: "Equal"
       value: "automq"
       effect: "NoSchedule"
   persistence:
-    storageClass: "${your-storage-class}"
-    size: 8Gi
+    # gp2 is the default storage class in AWS EKS.
+    # If you're using a different storage class, please update it here.
+    # Similar to Apache Kafka, AutoMQ requires a small disk to store metadata.
+    storageClass: "gp2"
+    size: 20Gi


### PR DESCRIPTION
This pull request introduces several improvements to the Helm `values.yaml` files used for deploying AutoMQ on Kubernetes. The goal of these changes is to simplify the configuration process for users, improve readability, and align with best practices.

### Key Changes:

*   **Standardized Resource Definitions**: CPU resource requests and limits have been standardized (e.g., `3000m` is now `3`).
*   **Simplified Affinity Rules**: Removed the complex `podAntiAffinity` rules to make the default configuration more broadly applicable and easier to understand. Users can add their own affinity rules if needed.
*   **Improved StorageClass Configuration**:
    *   Replaced the placeholder `${your-storage-class}` with `gp2`, the default for AWS EKS.
    *   Added comments to clarify that this disk is for metadata and to instruct users on how to change it for other environments.
*   **Updated Image Tag**: The default AutoMQ image tag has been updated to `1.5.3-rc0-bitnami`.
*   **Enhanced Comments and Readability**:
    *   Added explanations for key settings like `allowInsecureImages` and the multi-AZ `automq.zonerouter.channels` configuration.
    *   Cleaned up and standardized comments throughout the files.
*   **Consistent Replica Counts**: Adjusted broker replica counts in the base and TLS demo files for consistency.

These changes make the Helm deployment process more straightforward and user-friendly.