### PR TITLE
docs: Add and optimize READMEs for Kubernetes deployments

### DIFF
--- a/opensource-setup/kubernetes/README.md
+++ b/opensource-setup/kubernetes/README.md
@@ -17,27 +17,21 @@ Before you begin, ensure you have the following:
 
 ## Installation Steps
 
-### 1. Configure `values.yaml`
+### 1. Configure `demo-values.yaml`
 
 The key to deploying AutoMQ is to provide a custom `values.yaml` file that configures the Bitnami Kafka chart to use AutoMQ's container image and settings.
 
-We provide a `demo-values.yaml` in this directory that is pre-configured for deploying AutoMQ on AWS using `m7g.xlarge` instances. You can use it as a starting point.
+We provide a `demo-values.yaml` in this directory that is pre-configured for deploying AutoMQ on AWS using `m7g.xlarge` instances.
 
 **Action:**
 
-Create a copy of `demo-values.yaml` named `my-values.yaml` and customize it for your environment.
-
-```shell
-cp demo-values.yaml my-values.yaml
-```
-
-You will need to replace the placeholder values (marked with `${...}`) in `my-values.yaml`, such as the S3 bucket names (`ops-bucket`, `data-bucket`), AWS region, and endpoint.
+Edit the `demo-values.yaml` file and customize it for your environment. You will need to replace the placeholder values (marked with `${...}`), such as the S3 bucket names (`ops-bucket`, `data-bucket`), AWS region, and endpoint.
 
 For more details on performance tuning and available parameters, refer to the [AutoMQ Performance Tuning Guide](https://www.automq.com/docs/automq/deployment/performance-tuning-for-broker) and the official [Bitnami Kafka chart values](https://github.com/bitnami/charts/blob/main/bitnami/kafka/values.yaml).
 
 ### 2. Install the Helm Chart
 
-Once your `my-values.yaml` file is ready, use the `helm install` command to deploy AutoMQ. We recommend using a version from the `31.x` series of the Bitnami Kafka chart for best compatibility.
+Once your `demo-values.yaml` file is ready, use the `helm install` command to deploy AutoMQ. We recommend using a version from the `31.x` series of the Bitnami Kafka chart for best compatibility.
 
 **Action:**
 
@@ -45,7 +39,7 @@ Run the following command to install AutoMQ in a dedicated namespace:
 
 ```shell
 helm install automq-release oci://registry-1.docker.io/bitnamicharts/kafka \
-  -f my-values.yaml \
+  -f demo-values.yaml \
   --version 31.5.0 \
   --namespace automq \
   --create-namespace
@@ -57,11 +51,11 @@ This command will create a new release named `automq-release` in the `automq` na
 
 ### Upgrading the Deployment
 
-To apply changes to your deployment (e.g., after updating `my-values.yaml`), use the `helm upgrade` command:
+To apply changes to your deployment after updating `demo-values.yaml`, use the `helm upgrade` command:
 
 ```shell
 helm upgrade automq-release oci://registry-1.docker.io/bitnamicharts/kafka \
-  -f my-values.yaml \
+  -f demo-values.yaml \
   --version 31.5.0 \
   --namespace automq
 ```

--- a/opensource-setup/kubernetes/multi-az/README.md
+++ b/opensource-setup/kubernetes/multi-az/README.md
@@ -1,0 +1,77 @@
+# Deploy a Multi-AZ AutoMQ Cluster to Eliminate Cross-Zone Traffic Costs
+
+This guide explains how to deploy AutoMQ across multiple Availability Zones (AZs) on Kubernetes. This setup is designed to eliminate inter-zone data transfer costs, which can be a significant expense in cloud environments like AWS and GCP.
+
+## How It Works
+
+AutoMQ's **Zone Router** feature intelligently routes traffic to ensure that clients communicate with brokers in the same AZ whenever possible. This is achieved through a combination of server-side configurations and a rack-aware client setup. When a client in `zone-a` needs to fetch data, the system ensures it connects to a broker replica also in `zone-a`, thus avoiding network charges.
+
+For a detailed explanation of the mechanism, please refer to our official documentation:
+*   [**Overview of Eliminating Inter-Zone Traffic**](https://www.automq.com/docs/automq/eliminate-inter-zone-traffics/overview)
+
+## Prerequisites
+
+Ensure you have met the prerequisites outlined in the main [Kubernetes deployment guide](../README.md), including having a running Kubernetes cluster and Helm installed. Your Kubernetes cluster must span multiple availability zones.
+
+## Configuration for Multi-AZ Deployment
+
+The key to a multi-AZ deployment lies in the `demo-multi-az-values.yaml` file. It contains specific configurations to enable zone awareness and balanced pod distribution.
+
+### Key Configuration Parameters
+
+1.  **`topologySpreadConstraints`**:
+    This standard Kubernetes feature ensures that broker and controller pods are distributed evenly across different availability zones. It prevents all pods from being scheduled into a single zone.
+    ```yaml
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: broker
+    ```
+
+2.  **`brokerRackAssignment`**:
+    This setting tells AutoMQ how to determine the "rack" (i.e., the Availability Zone) of a broker. For cloud environments, this can often be done automatically.
+    ```yaml
+    # aws-az and azure are supported here
+    brokerRackAssignment: aws-az
+    ```
+    *   `aws-az`: (Recommended for AWS) AutoMQ automatically discovers the AZ from the node's metadata.
+    *   `azure`: (Recommended for Azure) AutoMQ automatically discovers the AZ from the node's metadata.
+
+3.  **`automq.zonerouter.channels`**:
+    This is the core setting that activates the Zone Router feature. It requires the same S3 bucket information as your data buckets and enables the brokers to coordinate traffic routing within zones.
+    ```yaml
+    # Enable this configuration to allow the zone router to eliminate cross-zone traffic.
+    # Apply it only for AWS and GCP, as other cloud vendors do not charge for cross-zone traffic.
+    automq.zonerouter.channels=0@s3://${data-bucket}?region=${region}&endpoint=${endpoint}
+    ```
+
+## Deployment Steps
+
+1.  **Edit `demo-multi-az-values.yaml`**:
+    Open the `demo-multi-az-values.yaml` file and replace the placeholder values for your S3 buckets (`${ops-bucket}`, `${data-bucket}`), AWS region, and endpoint.
+
+2.  **Install the Helm Chart**:
+    Use the `helm install` command with the multi-az values file.
+    ```shell
+    helm install automq-multi-az oci://registry-1.docker.io/bitnamicharts/kafka \
+      -f demo-multi-az-values.yaml \
+      --version 31.5.0 \
+      --namespace automq \
+      --create-namespace
+    ```
+
+## Important: Configure Your Clients for Rack Awareness
+
+Server-side configuration is only half the solution. To eliminate cross-AZ traffic, your Kafka clients **must** be configured to be rack-aware. This allows them to identify their own zone and connect to a broker in the same zone.
+
+Please follow the detailed instructions in our documentation to configure your clients:
+*   [**Client Configuration for Eliminating Inter-Zone Traffic**](https://www.automq.com/docs/automq/eliminate-inter-zone-traffics/client-configuration)
+
+## Verifying the Setup
+
+After deployment, you can confirm that cross-AZ traffic is eliminated by monitoring your cloud provider's network metrics. For AWS users, we provide a specific guide on how to do this using AWS Cost Explorer.
+
+*   [**How to Monitor Inter-Zone Traffic on AWS**](https://www.automq.com/docs/automq/eliminate-inter-zone-traffics/monitor-inter-zone-traffic)


### PR DESCRIPTION
This pull request introduces a series of documentation improvements for the Kubernetes-based deployment guides in `opensource-setup/kubernetes/`.

### Key Changes:

1.  **New Multi-AZ README**:
    *   A new `README.md` has been added to `opensource-setup/kubernetes/multi-az/`.
    *   It explains how to configure a multi-AZ AutoMQ cluster to eliminate cross-zone traffic costs.
    *   Highlights key parameters like `topologySpreadConstraints`, `brokerRackAssignment`, and `automq.zonerouter.channels`.
    *   Includes links to official documentation for the underlying mechanism, client configuration, and monitoring methods.

2.  **Improved TLS README**:
    *   The guide for setting up mTLS in `opensource-setup/kubernetes/tls/README.md` has been restructured for better clarity and flow.
    *   The steps are now more sequential, guiding the user from certificate generation to client testing without jumping between sections.

3.  **Simplified Main Kubernetes README**:
    *   The main guide in `opensource-setup/kubernetes/README.md` has been simplified.
    *   Removed the step requiring users to copy `demo-values.yaml` to `my-values.yaml`, making the process more direct.

These changes make the instructions for deploying AutoMQ on Kubernetes clearer, more comprehensive, and easier for users to follow.