### PR TITLE
feat(deploy): Add Docker Compose setups and README

### DIFF
--- a/opensource-setup/docker-compose/README.md
+++ b/opensource-setup/docker-compose/README.md
@@ -1,1 +1,112 @@
-# Placeholder
+# Deploy AutoMQ Locally with Docker Compose and MinIO
+
+This guide provides instructions for deploying AutoMQ locally using Docker Compose. It offers two configurations for different testing needs:
+
+1.  **Single-Node Cluster**: A minimal setup with one AutoMQ broker, perfect for quick functional testing and development.
+2.  **Three-Node Cluster**: A more realistic setup with three AutoMQ brokers, ideal for testing clustering features and client failover.
+
+Both setups use **MinIO** as a self-hosted, S3-compatible object storage backend.
+
+## Prerequisites
+
+*   [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) installed on your machine.
+*   Kafka command-line tools installed locally, or you can run them from within the Docker containers as shown below.
+
+## Deployment
+
+Choose one of the following options to start your local AutoMQ cluster.
+
+### Option 1: Deploy a Single-Node Cluster
+
+This is the quickest way to get a single AutoMQ broker running.
+
+```shell
+docker compose -f docker-compose-single-node.yml up -d
+```
+
+### Option 2: Deploy a Three-Node Cluster
+
+This setup simulates a production-like environment with three brokers.
+
+```shell
+docker compose -f docker-compose-cluster.yml up -d
+```
+
+## Testing the Deployment
+
+After starting the cluster, you can use standard Kafka tools to interact with it.
+
+### Connecting to the Cluster
+
+*   **Single-Node Bootstrap Server**: `server1:9092`
+*   **Three-Node Bootstrap Servers**: `server1:9092,server2:9092,server3:9092`
+
+### Running Kafka Tools
+
+The easiest way to run Kafka tools without a local installation is to execute them inside one of the running containers. We'll use `server1` for our examples.
+
+#### 1. Basic Produce & Consume Test
+
+**Open a terminal and start a producer** to send messages to a topic named `my-topic`:
+
+```shell
+docker compose exec server1 bash -c "                                       \
+  /opt/automq/kafka/bin/kafka-console-producer.sh                            \
+    --broker-list server1:9092                                              \
+    --topic my-topic"
+```
+
+Type some messages and press `Ctrl+D` when you are finished.
+
+**Open a second terminal and start a consumer** to receive the messages:
+
+```shell
+docker compose exec server1 bash -c "                                       \
+  /opt/automq/kafka/bin/kafka-console-consumer.sh                            \
+    --bootstrap-server server1:9092                                         \
+    --topic my-topic                                                          \
+    --from-beginning"
+```
+
+You should see the messages you sent earlier. Press `Ctrl+C` to exit.
+
+#### 2. Simple Performance Test
+
+You can run a small-scale performance test using `kafka-producer-perf-test.sh`. This example sends 1,024,000 messages of 1KB each to the `test-topic`.
+
+**For a three-node cluster**, use all bootstrap servers for the test:
+
+```shell
+docker compose exec server1 bash -c "                                       \
+  /opt/automq/kafka/bin/kafka-producer-perf-test.sh --topic test-topic --num-records=1024000 --throughput 5120 --record-size 1024 --producer-props bootstrap.servers=server1:9092,server2:9092,server3:9092 linger.ms=100 batch.size=524288 buffer.memory=134217728 max.request.size=67108864"
+```
+
+*(For a single-node cluster, simply change the `bootstrap.servers` value to `server1:9092`)*
+
+#### A Note on Performance Tuning
+
+> AutoMQ's architecture is built on object storage like S3. While this provides significant benefits in cost and scalability, it can introduce higher latency compared to traditional disk-based brokers.
+>
+> To achieve high throughput, it is crucial to optimize client-side configurations (e.g., `linger.ms`, `batch.size`). For detailed guidance, please refer to our official documentation:
+>
+> *   **[Performance Tuning for Clients](https://www.automq.com/docs/automq/configuration/performance-tuning-for-client)**
+
+## Shutdown and Cleanup
+
+To stop the containers and remove the network, run the `down` command corresponding to your deployment file.
+
+**For Single-Node:**
+```shell
+docker compose -f docker-compose-single-node.yml down
+```
+
+**For Three-Node:**
+```shell
+docker compose -f docker-compose-cluster.yml down
+```
+
+To **delete all data** stored in the MinIO volume, add the `-v` flag:
+```shell
+# Example for three-node cluster
+docker compose -f docker-compose-cluster.yml down -v
+```

--- a/opensource-setup/docker-compose/README.md
+++ b/opensource-setup/docker-compose/README.md
@@ -21,7 +21,7 @@ Choose one of the following options to start your local AutoMQ cluster.
 This is the quickest way to get a single AutoMQ broker running.
 
 ```shell
-docker compose -f docker-compose-single-node.yml up -d
+docker compose -f docker-compose.yaml up -d
 ```
 
 ### Option 2: Deploy a Three-Node Cluster
@@ -29,7 +29,7 @@ docker compose -f docker-compose-single-node.yml up -d
 This setup simulates a production-like environment with three brokers.
 
 ```shell
-docker compose -f docker-compose-cluster.yml up -d
+docker compose -f docker-compose-cluster.yaml up -d
 ```
 
 ## Testing the Deployment
@@ -43,25 +43,25 @@ After starting the cluster, you can use standard Kafka tools to interact with it
 
 ### Running Kafka Tools
 
-The easiest way to run Kafka tools without a local installation is to execute them inside one of the running containers. We'll use `server1` for our examples.
+The easiest way to run Kafka tools without a local installation is to execute them inside one of the running containers. We'll use `automq-server1` for our examples.
 
 #### 1. Basic Produce & Consume Test
 
 **Open a terminal and start a producer** to send messages to a topic named `my-topic`:
 
 ```shell
-docker compose exec server1 bash -c "                                       \
+docker exec automq-server1 bash -c "                                       \
   /opt/automq/kafka/bin/kafka-console-producer.sh                            \
     --broker-list server1:9092                                              \
     --topic my-topic"
 ```
 
-Type some messages and press `Ctrl+D` when you are finished.
+Type some messages and press `Ctrl+C` when you are finished.
 
 **Open a second terminal and start a consumer** to receive the messages:
 
 ```shell
-docker compose exec server1 bash -c "                                       \
+docker exec -it automq-server1 bash -c "                                       \
   /opt/automq/kafka/bin/kafka-console-consumer.sh                            \
     --bootstrap-server server1:9092                                         \
     --topic my-topic                                                          \
@@ -77,7 +77,7 @@ You can run a small-scale performance test using `kafka-producer-perf-test.sh`. 
 **For a three-node cluster**, use all bootstrap servers for the test:
 
 ```shell
-docker compose exec server1 bash -c "                                       \
+docker exec -it automq-server1 bash -c "                                       \
   /opt/automq/kafka/bin/kafka-producer-perf-test.sh --topic test-topic --num-records=1024000 --throughput 5120 --record-size 1024 --producer-props bootstrap.servers=server1:9092,server2:9092,server3:9092 linger.ms=100 batch.size=524288 buffer.memory=134217728 max.request.size=67108864"
 ```
 
@@ -97,16 +97,10 @@ To stop the containers and remove the network, run the `down` command correspond
 
 **For Single-Node:**
 ```shell
-docker compose -f docker-compose-single-node.yml down
+docker compose -f docker-compose.yaml down
 ```
 
 **For Three-Node:**
 ```shell
-docker compose -f docker-compose-cluster.yml down
-```
-
-To **delete all data** stored in the MinIO volume, add the `-v` flag:
-```shell
-# Example for three-node cluster
-docker compose -f docker-compose-cluster.yml down -v
+docker compose -f docker-compose-cluster.yaml down
 ```

--- a/opensource-setup/docker-compose/docker-compose-cluster.yaml
+++ b/opensource-setup/docker-compose/docker-compose-cluster.yaml
@@ -1,0 +1,155 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Single-node AutoMQ setup with MinIO for quick starts
+version: "3.8"
+
+x-common-variables: &common-env
+  KAFKA_S3_ACCESS_KEY: minioadmin
+  KAFKA_S3_SECRET_KEY: minioadmin
+  KAFKA_HEAP_OPTS: -Xms1g -Xmx4g -XX:MetaspaceSize=96m -XX:MaxDirectMemorySize=1G
+  # Replace CLUSTER_ID with a unique base64 UUID using "bin/kafka-storage.sh random-uuid"
+  CLUSTER_ID: 5XF4fHIOTfSIqkmje2KFlg
+
+services:
+  # MinIO service for S3 storage
+  minio:
+    container_name: "minio"
+    image: minio/minio:RELEASE.2025-05-24T17-08-30Z
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+      MINIO_DOMAIN: minio
+    ports:
+      - "9000:9000"  # MinIO API
+      - "9001:9001"  # MinIO Console
+    command: [ "server", "/data", "--console-address", ":9001" ]
+    networks:
+      automq_net:
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://minio:9000/minio/health/live" ]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+
+  # Create needed buckets
+  mc:
+    container_name: "mc"
+    image: minio/mc:RELEASE.2025-05-21T01-59-54Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      until (/usr/bin/mc alias set minio http://minio:9000 minioadmin minioadmin) do echo '...waiting...' && sleep 1; done;
+      /usr/bin/mc rm -r --force minio/automq-data;
+      /usr/bin/mc rm -r --force minio/automq-ops;
+      /usr/bin/mc mb minio/automq-data;
+      /usr/bin/mc mb minio/automq-ops;
+      /usr/bin/mc anonymous set public minio/automq-data;
+      /usr/bin/mc anonymous set public minio/automq-ops;
+      tail -f /dev/null
+      "
+    networks:
+      - automq_net
+
+  # Three nodes for AutoMQ cluster
+  server1:
+    container_name: "automq-server1"
+    image: automqinc/automq:1.5.3-rc0
+    stop_grace_period: 1m
+    environment:
+      <<: *common-env
+    command:
+      - bash
+      - -c
+      - |
+        /opt/automq/kafka/bin/kafka-server-start.sh \
+        /opt/automq/kafka/config/kraft/server.properties \
+        --override cluster.id=$$CLUSTER_ID \
+        --override node.id=0 \
+        --override controller.quorum.voters=0@server1:9093,1@server2:9093,2@server3:9093 \
+        --override controller.quorum.bootstrap.servers=server1:9093,server2:9093,server3:9093 \
+        --override advertised.listeners=PLAINTEXT://server1:9092 \
+        --override s3.data.buckets='0@s3://automq-data?region=us-east-1&endpoint=http://minio:9000&pathStyle=true' \
+        --override s3.ops.buckets='1@s3://automq-ops?region=us-east-1&endpoint=http://minio:9000&pathStyle=true' \
+        --override s3.wal.path='0@s3://automq-data?region=us-east-1&endpoint=http://minio:9000&pathStyle=true'
+    networks:
+      automq_net:
+    depends_on:
+      - minio
+      - mc
+
+  server2:
+    container_name: "automq-server2"
+    image: automqinc/automq:1.5.3-rc0
+    stop_grace_period: 1m
+    environment:
+      <<: *common-env
+    command:
+      - bash
+      - -c
+      - |
+        /opt/automq/kafka/bin/kafka-server-start.sh \
+        /opt/automq/kafka/config/kraft/server.properties \
+        --override cluster.id=$$CLUSTER_ID \
+        --override node.id=1 \
+        --override controller.quorum.voters=0@server1:9093,1@server2:9093,2@server3:9093 \
+        --override controller.quorum.bootstrap.servers=server1:9093,server2:9093,server3:9093 \
+        --override advertised.listeners=PLAINTEXT://server2:9092 \
+        --override s3.data.buckets='0@s3://automq-data?region=us-east-1&endpoint=http://minio:9000&pathStyle=true' \
+        --override s3.ops.buckets='1@s3://automq-ops?region=us-east-1&endpoint=http://minio:9000&pathStyle=true' \
+        --override s3.wal.path='0@s3://automq-data?region=us-east-1&endpoint=http://minio:9000&pathStyle=true'
+    networks:
+      automq_net:
+    depends_on:
+      - minio
+      - mc
+
+  server3:
+    container_name: "automq-server3"
+    image: automqinc/automq:1.5.3-rc0
+    stop_grace_period: 1m
+    environment:
+      <<: *common-env
+    command:
+      - bash
+      - -c
+      - |
+        /opt/automq/kafka/bin/kafka-server-start.sh \
+        /opt/automq/kafka/config/kraft/server.properties \
+        --override cluster.id=$$CLUSTER_ID \
+        --override node.id=2 \
+        --override controller.quorum.voters=0@server1:9093,1@server2:9093,2@server3:9093 \
+        --override controller.quorum.bootstrap.servers=server1:9093,server2:9093,server3:9093 \
+        --override advertised.listeners=PLAINTEXT://server3:9092 \
+        --override s3.data.buckets='0@s3://automq-data?region=us-east-1&endpoint=http://minio:9000&pathStyle=true' \
+        --override s3.ops.buckets='1@s3://automq-ops?region=us-east-1&endpoint=http://minio:9000&pathStyle=true' \
+        --override s3.wal.path='0@s3://automq-data?region=us-east-1&endpoint=http://minio:9000&pathStyle=true'
+    networks:
+      automq_net:
+    depends_on:
+      - minio
+      - mc
+
+networks:
+  automq_net:
+    name: automq_net
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: "10.6.0.0/16"
+          gateway: "10.6.0.1"

--- a/opensource-setup/docker-compose/docker-compose.yaml
+++ b/opensource-setup/docker-compose/docker-compose.yaml
@@ -60,7 +60,7 @@ services:
 
   # Single node with combined controller and broker roles
   server1:
-    container_name: "automq-single-server"
+    container_name: "automq-server1"
     image: automqinc/automq:1.5.3-rc0
     stop_grace_period: 1m
     environment:

--- a/opensource-setup/docker-compose/docker-compose.yaml
+++ b/opensource-setup/docker-compose/docker-compose.yaml
@@ -1,0 +1,100 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Single-node AutoMQ setup with MinIO for quick starts
+version: "3.8"
+
+services:
+  # MinIO service for S3 storage
+  minio:
+    container_name: "minio"
+    image: minio/minio:RELEASE.2025-05-24T17-08-30Z
+    environment:
+      - MINIO_ROOT_USER=minioadmin
+      - MINIO_ROOT_PASSWORD=minioadmin
+      - MINIO_DOMAIN=minio
+    ports:
+      - "9000:9000"  # MinIO API
+      - "9001:9001"  # MinIO Console
+    command: [ "server", "/data", "--console-address", ":9001" ]
+    networks:
+      automq_net:
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://minio:9000/minio/health/live" ]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+
+  # Create needed buckets
+  mc:
+    container_name: "mc"
+    image: minio/mc:RELEASE.2025-05-21T01-59-54Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      until (/usr/bin/mc alias set minio http://minio:9000 minioadmin minioadmin) do echo '...waiting...' && sleep 1; done;
+      /usr/bin/mc rm -r --force minio/automq-data;
+      /usr/bin/mc rm -r --force minio/automq-ops;
+      /usr/bin/mc mb minio/automq-data;
+      /usr/bin/mc mb minio/automq-ops;
+      /usr/bin/mc anonymous set public minio/automq-data;
+      /usr/bin/mc anonymous set public minio/automq-ops;
+      tail -f /dev/null
+      "
+    networks:
+      - automq_net
+
+  # Single node with combined controller and broker roles
+  server1:
+    container_name: "automq-single-server"
+    image: automqinc/automq:1.5.3-rc0
+    stop_grace_period: 1m
+    environment:
+      - KAFKA_S3_ACCESS_KEY=minioadmin
+      - KAFKA_S3_SECRET_KEY=minioadmin
+      - KAFKA_HEAP_OPTS=-Xms1g -Xmx4g -XX:MetaspaceSize=96m -XX:MaxDirectMemorySize=1G
+      # Replace CLUSTER_ID with a unique base64 UUID using "bin/kafka-storage.sh random-uuid"
+      - CLUSTER_ID=3D4fXN-yS1-vsQ8aJ_q4Mg
+    command:
+      - bash
+      - -c
+      - |
+        /opt/automq/kafka/bin/kafka-server-start.sh \
+        /opt/automq/kafka/config/kraft/server.properties \
+        --override cluster.id=$$CLUSTER_ID \
+        --override node.id=0 \
+        --override controller.quorum.voters=0@server1:9093 \
+        --override controller.quorum.bootstrap.servers=server1:9093 \
+        --override advertised.listeners=PLAINTEXT://server1:9092 \
+        --override s3.data.buckets='0@s3://automq-data?region=us-east-1&endpoint=http://minio:9000&pathStyle=true' \
+        --override s3.ops.buckets='1@s3://automq-ops?region=us-east-1&endpoint=http://minio:9000&pathStyle=true' \
+        --override s3.wal.path='0@s3://automq-data?region=us-east-1&endpoint=http://minio:9000&pathStyle=true'
+    networks:
+      automq_net:
+    depends_on:
+      - minio
+      - mc
+
+networks:
+  automq_net:
+    name: automq_net
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: "10.6.0.0/16"
+          gateway: "10.6.0.1"


### PR DESCRIPTION
This pull request adds a comprehensive local development setup using Docker Compose.

### Key Additions:

*   **`docker-compose-single-node.yml`**: A new compose file for deploying a single-node AutoMQ cluster.
*   **`docker-compose-cluster.yml`**: A new compose file for deploying a three-node AutoMQ cluster.
*   **MinIO Integration**: Both setups use MinIO as a local, S3-compatible storage backend.
*   **Updated `README.md`**: The `README.md` in the `opensource-setup/docker-compose/` directory has been completely rewritten to provide clear, step-by-step instructions for:
    *   Deploying both single-node and three-node clusters.
    *   Testing the deployment with `kafka-console-producer.sh` and `kafka-console-consumer.sh`.
    *   Running a simple performance test with `kafka-producer-perf-test.sh`.
    *   Guidance on client-side performance tuning for S3-based architectures.

This provides a robust and easy-to-use environment for local development and testing.