### PR TITLE
fix: Pin terraform-aws-iam module to version 5.60.0 to avoid breaking changes

### DIFF
--- a/kubernetes/aws/terraform/eks-addons/irsa.tf
+++ b/kubernetes/aws/terraform/eks-addons/irsa.tf
@@ -4,7 +4,7 @@
 module "lb_irsa_role" {
   count = var.enable_alb_ingress_controller ? 1 : 0
 
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "5.60.0"
 
   role_name                              = local.alb_controller_role_name
@@ -24,7 +24,7 @@ module "lb_irsa_role" {
 module "ebs-csi-irsa-role" {
   count = var.enable_ebs_csi_driver ? 1 : 0
 
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "5.60.0"
 
   role_name             = local.ebs_csi_role_name
@@ -44,7 +44,7 @@ module "ebs-csi-irsa-role" {
 module "cluster_autoscaler_irsa_role" {
   count = var.enable_autoscaler ? 1 : 0
 
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "5.60.0"
 
   role_name                        = local.cluster_autoscaler_role_name

--- a/kubernetes/aws/terraform/eks-addons/irsa.tf
+++ b/kubernetes/aws/terraform/eks-addons/irsa.tf
@@ -5,6 +5,7 @@ module "lb_irsa_role" {
   count = var.enable_alb_ingress_controller ? 1 : 0
 
   source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.60.0"
 
   role_name                              = local.alb_controller_role_name
   attach_load_balancer_controller_policy = true
@@ -24,6 +25,7 @@ module "ebs-csi-irsa-role" {
   count = var.enable_ebs_csi_driver ? 1 : 0
 
   source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.60.0"
 
   role_name             = local.ebs_csi_role_name
   attach_ebs_csi_policy = true
@@ -43,6 +45,7 @@ module "cluster_autoscaler_irsa_role" {
   count = var.enable_autoscaler ? 1 : 0
 
   source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.60.0"
 
   role_name                        = local.cluster_autoscaler_role_name
   attach_cluster_autoscaler_policy = true


### PR DESCRIPTION
## Problem

The `terraform-aws-modules/terraform-aws-iam` module version 6.0 introduced breaking changes that renamed several modules, including `iam-role-for-service-accounts-eks`. This is related to [PR #585](https://github.com/terraform-aws-modules/terraform-aws-iam/pull/585) in the upstream repository.

Users upgrading to version 6.0 are experiencing issues due to these module name changes.

## Solution

Pin the IAM module version to `5.60.0` for all IRSA (IAM Roles for Service Accounts) configurations in the EKS addons to ensure stability and prevent breaking changes.

## Changes

- Added `version = "5.60.0"` to all `terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks` module definitions in `kubernetes/aws/terraform/eks-addons/irsa.tf`
- This affects:
  - Load Balancer Controller Role
  - EBS CSI Driver Role  
  - Cluster Autoscaler Role
