### PR TITLE
fix(strimzi): fix template to prevent config overrides

### DIFF
--- a/opensource-examples/setup/kubernetes/strimzi/automq-demo.yaml
+++ b/opensource-examples/setup/kubernetes/strimzi/automq-demo.yaml
@@ -59,8 +59,13 @@ spec:
               strimzi.io/pool-name: controller
     kafkaContainer:
       env:
+        # Replace the following with your own config.
         - name: "KAFKA_HEAP_OPTS"
           value: "-Xmx6g -Xms6g -XX:MaxDirectMemorySize=6g -XX:MetaspaceSize=96m"
+        - name: KAFKA_S3_ACCESS_KEY
+          value: "${access-key}"
+        - name: KAFKA_S3_SECRET_KEY
+          value: "${secret-key}"
 ---
 
 apiVersion: kafka.strimzi.io/v1beta2
@@ -125,8 +130,13 @@ spec:
               strimzi.io/pool-name: broker
     kafkaContainer:
       env:
+        # Replace the following with your own config.
         - name: "KAFKA_HEAP_OPTS"
           value: "-Xmx6g -Xms6g -XX:MaxDirectMemorySize=6g -XX:MetaspaceSize=96m"
+        - name: KAFKA_S3_ACCESS_KEY
+          value: "${access-key}"
+        - name: KAFKA_S3_SECRET_KEY
+          value: "${secret-key}"
 ---
 
 apiVersion: kafka.strimzi.io/v1beta2
@@ -158,14 +168,6 @@ spec:
       s3.wal.path: "0@s3://${data-bucket}?region=${region}&endpoint=${endpoint}"
       automq.zonerouter.channels: "0@s3://${data-bucket}?region=${region}&endpoint=${endpoint}"
       autobalancer.client.listener.name: PLAIN1-9092
-    template:
-      kafkaContainer:
-        # Replace the following with your own config.
-        env:
-          - name: KAFKA_S3_ACCESS_KEY
-            value: "${access-key}"
-          - name: KAFKA_S3_SECRET_KEY
-            value: "${secret-key}"
     rack:
       topologyKey: topology.kubernetes.io/zone
   entityOperator:


### PR DESCRIPTION
from the docs as we known, the nodepool's  template config will overrides the kafka cluster's template config, so if use this demo config,  can't inject the access key into pod envs, which cause  the pods  to fail on starup.
<img width="1153" height="282" alt="image" src="https://github.com/user-attachments/assets/a2883a32-e791-40d7-a428-eb6d3133ec65" />
