### PR TITLE
fix: add curl download support and embed helper scripts inline

### DIFF
--- a/software-examples/binary/setup.sh
+++ b/software-examples/binary/setup.sh
@@ -4,9 +4,6 @@
 
 set -e
 
-# GitHub raw URL base
-GITHUB_RAW_BASE="https://raw.githubusercontent.com/AutoMQ/automq-labs/main/software-examples/binary"
-
 # Configuration
 AUTOMQ_VERSION="5.3.4"
 AUTOMQ_DOWNLOAD_URL="https://go.automq.com/software_${AUTOMQ_VERSION}"
@@ -22,17 +19,9 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-print_info() {
-    printf "${GREEN}[INFO]${NC} %s\n" "$1"
-}
-
-print_warn() {
-    printf "${YELLOW}[WARN]${NC} %s\n" "$1"
-}
-
-print_error() {
-    printf "${RED}[ERROR]${NC} %s\n" "$1"
-}
+print_info() { printf "${GREEN}[INFO]${NC} %s\n" "$1"; }
+print_warn() { printf "${YELLOW}[WARN]${NC} %s\n" "$1"; }
+print_error() { printf "${RED}[ERROR]${NC} %s\n" "$1"; }
 
 print_header() {
     echo ""
@@ -46,7 +35,6 @@ check_prerequisites() {
     print_info "Checking prerequisites..."
     local has_error=0
 
-    # Check curl
     if ! command -v curl &> /dev/null; then
         print_error "curl is not installed."
         has_error=1
@@ -54,7 +42,6 @@ check_prerequisites() {
         print_info "✓ curl found"
     fi
 
-    # Check Java
     if ! command -v java &> /dev/null; then
         print_error "Java is not installed. Please install Java 17 or later."
         has_error=1
@@ -62,14 +49,13 @@ check_prerequisites() {
         local java_version
         java_version=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | cut -d'.' -f1)
         if [ "$java_version" -lt 17 ] 2>/dev/null; then
-            print_error "Java 17 or later is required. Current version: $java_version"
+            print_error "Java 17 or later is required."
             has_error=1
         else
-            print_info "✓ Java found: $(java -version 2>&1 | head -1)"
+            print_info "✓ Java found"
         fi
     fi
 
-    # Check Docker
     if ! command -v docker &> /dev/null; then
         print_error "Docker is not installed."
         has_error=1
@@ -78,45 +64,169 @@ check_prerequisites() {
             print_error "Docker daemon is not running."
             has_error=1
         else
-            print_info "✓ Docker found: $(docker --version)"
+            print_info "✓ Docker found"
         fi
     fi
 
-    # Check Docker Compose
-    if command -v docker-compose &> /dev/null; then
-        print_info "✓ Docker Compose found: $(docker-compose --version)"
-    elif docker compose version &> /dev/null; then
-        print_info "✓ Docker Compose found: $(docker compose version)"
+    if command -v docker-compose &> /dev/null || docker compose version &> /dev/null; then
+        print_info "✓ Docker Compose found"
     else
         print_error "Docker Compose is not installed."
         has_error=1
     fi
 
-    if [ $has_error -eq 1 ]; then
-        echo ""
-        print_error "Prerequisites check failed."
-        exit 1
-    fi
-
+    [ $has_error -eq 1 ] && { print_error "Prerequisites check failed."; exit 1; }
     print_info "All prerequisites satisfied!"
     echo ""
 }
 
-download_helper_scripts() {
-    print_info "Downloading helper scripts..."
-    
-    curl -sSL -o format-storage.sh "${GITHUB_RAW_BASE}/format-storage.sh"
+generate_helper_scripts() {
+    print_info "Generating helper scripts..."
+
+    # Generate format-storage.sh
+    cat > format-storage.sh << 'FORMAT_EOF'
+#!/bin/bash
+set -e
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+AUTOMQ_DIR="automq-kafka-enterprise_5.3.4"
+print_info() { printf "${GREEN}[INFO]${NC} %s\n" "$1"; }
+print_error() { printf "${RED}[ERROR]${NC} %s\n" "$1"; }
+
+echo ""
+echo "=============================================="
+echo " AutoMQ Storage Format"
+echo "=============================================="
+echo ""
+
+[ ! -d "$AUTOMQ_DIR" ] && { print_error "AutoMQ directory not found. Run setup.sh first."; exit 1; }
+
+print_info "Generating cluster ID..."
+cluster_id=$("$AUTOMQ_DIR/bin/kafka-storage.sh" random-uuid)
+print_info "Cluster ID: $cluster_id"
+echo ""
+
+print_info "Formatting Node 0..."
+"$AUTOMQ_DIR/bin/kafka-storage.sh" format -t "$cluster_id" -c "$AUTOMQ_DIR/config/kraft/node0.properties"
+
+print_info "Formatting Node 1..."
+"$AUTOMQ_DIR/bin/kafka-storage.sh" format -t "$cluster_id" -c "$AUTOMQ_DIR/config/kraft/node1.properties"
+
+print_info "Formatting Node 2..."
+"$AUTOMQ_DIR/bin/kafka-storage.sh" format -t "$cluster_id" -c "$AUTOMQ_DIR/config/kraft/node2.properties"
+
+echo ""
+print_info "All nodes formatted successfully!"
+echo ""
+echo "Now start the cluster in 3 separate terminals:"
+echo ""
+echo "# Terminal 1"
+echo "cd ${AUTOMQ_DIR} && export KAFKA_S3_ACCESS_KEY=admin && export KAFKA_S3_SECRET_KEY=automq_demo_secret && export KAFKA_HEAP_OPTS=\"-Xmx2g -Xms2g\" && bin/kafka-server-start.sh config/kraft/node0.properties"
+echo ""
+echo "# Terminal 2"
+echo "cd ${AUTOMQ_DIR} && export KAFKA_S3_ACCESS_KEY=admin && export KAFKA_S3_SECRET_KEY=automq_demo_secret && export KAFKA_HEAP_OPTS=\"-Xmx2g -Xms2g\" && bin/kafka-server-start.sh config/kraft/node1.properties"
+echo ""
+echo "# Terminal 3"
+echo "cd ${AUTOMQ_DIR} && export KAFKA_S3_ACCESS_KEY=admin && export KAFKA_S3_SECRET_KEY=automq_demo_secret && export KAFKA_HEAP_OPTS=\"-Xmx2g -Xms2g\" && bin/kafka-server-start.sh config/kraft/node2.properties"
+echo ""
+FORMAT_EOF
     chmod +x format-storage.sh
-    print_info "✓ Downloaded format-storage.sh"
+    print_info "✓ Generated format-storage.sh"
 
-    curl -sSL -o verify.sh "${GITHUB_RAW_BASE}/verify.sh"
+    # Generate verify.sh
+    cat > verify.sh << 'VERIFY_EOF'
+#!/bin/bash
+set -e
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+AUTOMQ_DIR="automq-kafka-enterprise_5.3.4"
+BOOTSTRAP_SERVER="localhost:9092"
+print_info() { printf "${GREEN}[INFO]${NC} %s\n" "$1"; }
+print_error() { printf "${RED}[ERROR]${NC} %s\n" "$1"; }
+
+echo ""
+echo "=============================================="
+echo " AutoMQ Installation Verification"
+echo "=============================================="
+echo ""
+
+[ ! -d "$AUTOMQ_DIR" ] && { print_error "AutoMQ directory not found."; exit 1; }
+
+print_info "Checking broker connectivity..."
+if ! "$AUTOMQ_DIR/bin/kafka-broker-api-versions.sh" --bootstrap-server "$BOOTSTRAP_SERVER" > /dev/null 2>&1; then
+    print_error "Cannot connect to broker at $BOOTSTRAP_SERVER"
+    exit 1
+fi
+print_info "✓ Broker is accessible"
+
+print_info "Creating test topic..."
+"$AUTOMQ_DIR/bin/kafka-topics.sh" --create --topic test-topic --partitions 3 --replication-factor 1 --bootstrap-server "$BOOTSTRAP_SERVER" --if-not-exists 2>/dev/null || true
+print_info "✓ Test topic created"
+
+print_info "Listing topics..."
+echo ""
+"$AUTOMQ_DIR/bin/kafka-topics.sh" --list --bootstrap-server "$BOOTSTRAP_SERVER"
+echo ""
+
+echo "=============================================="
+echo " Verification Complete!"
+echo "=============================================="
+echo ""
+print_info "AutoMQ cluster is running and accessible."
+echo ""
+echo "Bootstrap servers: localhost:9092, localhost:9093, localhost:9094"
+echo ""
+VERIFY_EOF
     chmod +x verify.sh
-    print_info "✓ Downloaded verify.sh"
+    print_info "✓ Generated verify.sh"
 
-    curl -sSL -o cleanup.sh "${GITHUB_RAW_BASE}/cleanup.sh"
+    # Generate cleanup.sh
+    cat > cleanup.sh << 'CLEANUP_EOF'
+#!/bin/bash
+set -e
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+AUTOMQ_DIR="automq-kafka-enterprise_5.3.4"
+print_info() { printf "${GREEN}[INFO]${NC} %s\n" "$1"; }
+print_warn() { printf "${YELLOW}[WARN]${NC} %s\n" "$1"; }
+
+echo ""
+echo "=============================================="
+echo " AutoMQ Cleanup"
+echo "=============================================="
+echo ""
+
+[ "$1" != "-y" ] && [ "$1" != "--yes" ] && {
+    printf "This will stop AutoMQ and MinIO, and remove data. Continue? [y/N] "
+    read -r REPLY
+    [[ ! "$REPLY" =~ ^[Yy] ]] && { print_info "Cleanup cancelled."; exit 0; }
+}
+echo ""
+
+print_info "Stopping AutoMQ nodes..."
+[ -d "$AUTOMQ_DIR" ] && "$AUTOMQ_DIR/bin/kafka-server-stop.sh" 2>/dev/null || true
+sleep 2
+print_info "✓ AutoMQ nodes stopped"
+
+print_info "Stopping MinIO..."
+[ -f "minio/docker-compose.yml" ] && docker compose -f minio/docker-compose.yml down -v 2>/dev/null || true
+print_info "✓ MinIO stopped"
+
+print_info "Removing data directories..."
+rm -rf /tmp/automq-data-* 2>/dev/null || true
+print_info "✓ Data directories removed"
+
+echo ""
+echo "=============================================="
+echo " Cleanup Complete!"
+echo "=============================================="
+echo ""
+CLEANUP_EOF
     chmod +x cleanup.sh
-    print_info "✓ Downloaded cleanup.sh"
-    
+    print_info "✓ Generated cleanup.sh"
     echo ""
 }
 
@@ -140,10 +250,9 @@ download_automq() {
 
 create_minio_compose() {
     print_info "Creating MinIO configuration..."
-    
     mkdir -p minio
     
-    cat <<'EOF' > minio/docker-compose.yml
+    cat > minio/docker-compose.yml << 'MINIO_EOF'
 services:
   minio:
     image: minio/minio:latest
@@ -179,8 +288,7 @@ services:
 
 volumes:
   minio-data:
-EOF
-
+MINIO_EOF
     print_info "✓ Created minio/docker-compose.yml"
 }
 
@@ -190,86 +298,30 @@ generate_node_configs() {
     local config_dir="$AUTOMQ_DIR_NAME/config/kraft"
     mkdir -p "$config_dir"
     
-    # S3 common config
     local s3_config="s3.data.buckets=0@s3://automq-data?region=us-east-1&endpoint=${MINIO_ENDPOINT}&pathStyle=true
 s3.ops.buckets=0@s3://automq-ops?region=us-east-1&endpoint=${MINIO_ENDPOINT}&pathStyle=true
 s3.wal.path=0@s3://automq-data?region=us-east-1&endpoint=${MINIO_ENDPOINT}&pathStyle=true"
 
-    # Node 0 config
-    cat <<EOF > "$config_dir/node0.properties"
-# Node 0 Configuration
-node.id=0
+    for i in 0 1 2; do
+        local port=$((9092 + i))
+        local ctrl_port=$((19092 + i))
+        cat > "$config_dir/node${i}.properties" << EOF
+node.id=${i}
 process.roles=broker,controller
-listeners=PLAINTEXT://127.0.0.1:9092,CONTROLLER://127.0.0.1:19092
-advertised.listeners=PLAINTEXT://127.0.0.1:9092
+listeners=PLAINTEXT://127.0.0.1:${port},CONTROLLER://127.0.0.1:${ctrl_port}
+advertised.listeners=PLAINTEXT://127.0.0.1:${port}
 controller.listener.names=CONTROLLER
 controller.quorum.voters=0@127.0.0.1:19092,1@127.0.0.1:19093,2@127.0.0.1:19094
 inter.broker.listener.name=PLAINTEXT
-
-# Log directories
-log.dirs=/tmp/automq-data-0
-
-# S3 Configuration
+log.dirs=/tmp/automq-data-${i}
 ${s3_config}
-
-# Default settings
 num.partitions=1
 default.replication.factor=1
 offsets.topic.replication.factor=1
 transaction.state.log.replication.factor=1
 transaction.state.log.min.isr=1
 EOF
-
-    # Node 1 config
-    cat <<EOF > "$config_dir/node1.properties"
-# Node 1 Configuration
-node.id=1
-process.roles=broker,controller
-listeners=PLAINTEXT://127.0.0.1:9093,CONTROLLER://127.0.0.1:19093
-advertised.listeners=PLAINTEXT://127.0.0.1:9093
-controller.listener.names=CONTROLLER
-controller.quorum.voters=0@127.0.0.1:19092,1@127.0.0.1:19093,2@127.0.0.1:19094
-inter.broker.listener.name=PLAINTEXT
-
-# Log directories
-log.dirs=/tmp/automq-data-1
-
-# S3 Configuration
-${s3_config}
-
-# Default settings
-num.partitions=1
-default.replication.factor=1
-offsets.topic.replication.factor=1
-transaction.state.log.replication.factor=1
-transaction.state.log.min.isr=1
-EOF
-
-    # Node 2 config
-    cat <<EOF > "$config_dir/node2.properties"
-# Node 2 Configuration
-node.id=2
-process.roles=broker,controller
-listeners=PLAINTEXT://127.0.0.1:9094,CONTROLLER://127.0.0.1:19094
-advertised.listeners=PLAINTEXT://127.0.0.1:9094
-controller.listener.names=CONTROLLER
-controller.quorum.voters=0@127.0.0.1:19092,1@127.0.0.1:19093,2@127.0.0.1:19094
-inter.broker.listener.name=PLAINTEXT
-
-# Log directories
-log.dirs=/tmp/automq-data-2
-
-# S3 Configuration
-${s3_config}
-
-# Default settings
-num.partitions=1
-default.replication.factor=1
-offsets.topic.replication.factor=1
-transaction.state.log.replication.factor=1
-transaction.state.log.min.isr=1
-EOF
-
+    done
     print_info "✓ Generated node0.properties, node1.properties, node2.properties"
 }
 
@@ -287,34 +339,10 @@ print_next_steps() {
     echo "2. Format storage (run once):"
     echo "   ./format-storage.sh"
     echo ""
-    echo "3. Start AutoMQ nodes (in 3 separate terminals):"
-    echo ""
-    echo "   # Terminal 1 - Node 0"
-    echo "   cd ${AUTOMQ_DIR_NAME}"
-    echo "   export KAFKA_S3_ACCESS_KEY=admin"
-    echo "   export KAFKA_S3_SECRET_KEY=automq_demo_secret"
-    echo "   export KAFKA_HEAP_OPTS=\"-Xmx2g -Xms2g\""
-    echo "   bin/kafka-server-start.sh config/kraft/node0.properties"
-    echo ""
-    echo "   # Terminal 2 - Node 1"
-    echo "   cd ${AUTOMQ_DIR_NAME}"
-    echo "   export KAFKA_S3_ACCESS_KEY=admin"
-    echo "   export KAFKA_S3_SECRET_KEY=automq_demo_secret"
-    echo "   export KAFKA_HEAP_OPTS=\"-Xmx2g -Xms2g\""
-    echo "   bin/kafka-server-start.sh config/kraft/node1.properties"
-    echo ""
-    echo "   # Terminal 3 - Node 2"
-    echo "   cd ${AUTOMQ_DIR_NAME}"
-    echo "   export KAFKA_S3_ACCESS_KEY=admin"
-    echo "   export KAFKA_S3_SECRET_KEY=automq_demo_secret"
-    echo "   export KAFKA_HEAP_OPTS=\"-Xmx2g -Xms2g\""
-    echo "   bin/kafka-server-start.sh config/kraft/node2.properties"
+    echo "3. Start AutoMQ nodes (in 3 separate terminals)"
     echo ""
     echo "4. Verify installation:"
     echo "   ./verify.sh"
-    echo ""
-    echo "5. Stop cluster:"
-    echo "   cd ${AUTOMQ_DIR_NAME} && bin/kafka-server-stop.sh"
     echo ""
     echo "MinIO Console: http://localhost:9001"
     echo "  Username: ${MINIO_USER}"
@@ -325,7 +353,7 @@ print_next_steps() {
 main() {
     print_header
     check_prerequisites
-    download_helper_scripts
+    generate_helper_scripts
     download_automq
     create_minio_compose
     generate_node_configs

--- a/software-examples/binary/setup.sh
+++ b/software-examples/binary/setup.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # AutoMQ Software Binary Deployment Setup Script
-# Supports: curl -sSL https://raw.githubusercontent.com/AutoMQ/automq-examples/main/software-examples/binary/setup.sh | bash
+# Supports: curl -sSL https://raw.githubusercontent.com/AutoMQ/automq-labs/main/software-examples/binary/setup.sh | bash
 
 set -e
 
 # GitHub raw URL base
-GITHUB_RAW_BASE="https://raw.githubusercontent.com/AutoMQ/automq-examples/main/software-examples/binary"
+GITHUB_RAW_BASE="https://raw.githubusercontent.com/AutoMQ/automq-labs/main/software-examples/binary"
 
 # Configuration
 AUTOMQ_VERSION="5.3.4"

--- a/software-examples/docker-compose/install.sh
+++ b/software-examples/docker-compose/install.sh
@@ -4,9 +4,6 @@
 
 set -e
 
-# GitHub raw URL base
-GITHUB_RAW_BASE="https://raw.githubusercontent.com/AutoMQ/automq-labs/main/software-examples/docker-compose"
-
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -57,27 +54,292 @@ if ! command -v docker-compose &> /dev/null && ! docker compose version &> /dev/
 fi
 print_success "Docker Compose is available"
 
-if ! command -v curl &> /dev/null; then
-    print_error "curl is not installed. Please install curl first."
-    exit 1
-fi
-print_success "curl is available"
-
 echo ""
 
-# Step 2: Download required files
-print_step "Step 2/5: Downloading configuration files..."
+# Step 2: Generate configuration files
+print_step "Step 2/5: Generating configuration files..."
 
-curl -sSL -o docker-compose.yaml "${GITHUB_RAW_BASE}/docker-compose.yaml"
-print_success "Downloaded docker-compose.yaml"
+# Generate docker-compose.yaml
+cat > docker-compose.yaml << 'DOCKER_COMPOSE_EOF'
+# AutoMQ Software Cluster with MinIO
+# Quick start deployment for local development and testing
+version: "3.8"
 
-curl -sSL -o verify.sh "${GITHUB_RAW_BASE}/verify.sh"
+x-common-variables: &common-env
+  KAFKA_S3_ACCESS_KEY: admin
+  KAFKA_S3_SECRET_KEY: automq_demo_secret
+  KAFKA_HEAP_OPTS: -Xms1g -Xmx4g -XX:MetaspaceSize=96m -XX:MaxDirectMemorySize=1G
+  CLUSTER_ID: rqbCPLBqQa2r9n0JMfFCzQ
+
+services:
+  minio:
+    container_name: "minio"
+    image: minio/minio:RELEASE.2025-05-24T17-08-30Z
+    environment:
+      MINIO_ROOT_USER: admin
+      MINIO_ROOT_PASSWORD: automq_demo_secret
+      MINIO_DOMAIN: minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    command: ["server", "/data", "--console-address", ":9001"]
+    networks:
+      automq_net:
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://minio:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+
+  mc:
+    container_name: "mc"
+    image: minio/mc:RELEASE.2025-05-21T01-59-54Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      until (/usr/bin/mc alias set minio http://minio:9000 admin automq_demo_secret) do echo '...waiting...' && sleep 1; done;
+      /usr/bin/mc rm -r --force minio/automq-data 2>/dev/null || true;
+      /usr/bin/mc rm -r --force minio/automq-ops 2>/dev/null || true;
+      /usr/bin/mc mb minio/automq-data;
+      /usr/bin/mc mb minio/automq-ops;
+      /usr/bin/mc anonymous set public minio/automq-data;
+      /usr/bin/mc anonymous set public minio/automq-ops;
+      echo 'Buckets created successfully';
+      tail -f /dev/null
+      "
+    networks:
+      - automq_net
+
+  controller1:
+    container_name: "automq-controller1"
+    image: automq.azurecr.io/automq/automq-enterprise:5.3.7
+    stop_grace_period: 1m
+    environment:
+      <<: *common-env
+    command:
+      - bash
+      - -c
+      - |
+        cat > /tmp/server.properties << EOF
+        process.roles=broker,controller
+        node.id=0
+        controller.quorum.voters=0@controller1:9093,1@controller2:9093,2@controller3:9093
+        controller.quorum.bootstrap.servers=controller1:9093,controller2:9093,controller3:9093
+        listeners=PLAINTEXT://:9092,CONTROLLER://:9093
+        inter.broker.listener.name=PLAINTEXT
+        advertised.listeners=PLAINTEXT://controller1:9092
+        controller.listener.names=CONTROLLER
+        log.dirs=/tmp/kraft-combined-logs
+        s3.data.buckets=0@s3://automq-data?region=us-east-1&endpoint=http://minio:9000&pathStyle=true
+        s3.ops.buckets=1@s3://automq-ops?region=us-east-1&endpoint=http://minio:9000&pathStyle=true
+        s3.wal.path=0@s3://automq-data?region=us-east-1&endpoint=http://minio:9000&pathStyle=true
+        num.partitions=1
+        offsets.topic.replication.factor=1
+        transaction.state.log.replication.factor=1
+        transaction.state.log.min.isr=1
+        EOF
+        /opt/automq/kafka/bin/kafka-storage.sh format -t "$$CLUSTER_ID" -c /tmp/server.properties --ignore-formatted || true
+        exec /opt/automq/kafka/bin/kafka-server-start.sh /tmp/server.properties
+    ports:
+      - "19092:9092"
+    networks:
+      automq_net:
+    depends_on:
+      minio:
+        condition: service_healthy
+      mc:
+        condition: service_started
+
+  controller2:
+    container_name: "automq-controller2"
+    image: automq.azurecr.io/automq/automq-enterprise:5.3.7
+    stop_grace_period: 1m
+    environment:
+      <<: *common-env
+    command:
+      - bash
+      - -c
+      - |
+        cat > /tmp/server.properties << EOF
+        process.roles=broker,controller
+        node.id=1
+        controller.quorum.voters=0@controller1:9093,1@controller2:9093,2@controller3:9093
+        controller.quorum.bootstrap.servers=controller1:9093,controller2:9093,controller3:9093
+        listeners=PLAINTEXT://:9092,CONTROLLER://:9093
+        inter.broker.listener.name=PLAINTEXT
+        advertised.listeners=PLAINTEXT://controller2:9092
+        controller.listener.names=CONTROLLER
+        log.dirs=/tmp/kraft-combined-logs
+        s3.data.buckets=0@s3://automq-data?region=us-east-1&endpoint=http://minio:9000&pathStyle=true
+        s3.ops.buckets=1@s3://automq-ops?region=us-east-1&endpoint=http://minio:9000&pathStyle=true
+        s3.wal.path=0@s3://automq-data?region=us-east-1&endpoint=http://minio:9000&pathStyle=true
+        num.partitions=1
+        offsets.topic.replication.factor=1
+        transaction.state.log.replication.factor=1
+        transaction.state.log.min.isr=1
+        EOF
+        /opt/automq/kafka/bin/kafka-storage.sh format -t "$$CLUSTER_ID" -c /tmp/server.properties --ignore-formatted || true
+        exec /opt/automq/kafka/bin/kafka-server-start.sh /tmp/server.properties
+    ports:
+      - "29092:9092"
+    networks:
+      automq_net:
+    depends_on:
+      minio:
+        condition: service_healthy
+      mc:
+        condition: service_started
+
+  controller3:
+    container_name: "automq-controller3"
+    image: automq.azurecr.io/automq/automq-enterprise:5.3.7
+    stop_grace_period: 1m
+    environment:
+      <<: *common-env
+    command:
+      - bash
+      - -c
+      - |
+        cat > /tmp/server.properties << EOF
+        process.roles=broker,controller
+        node.id=2
+        controller.quorum.voters=0@controller1:9093,1@controller2:9093,2@controller3:9093
+        controller.quorum.bootstrap.servers=controller1:9093,controller2:9093,controller3:9093
+        listeners=PLAINTEXT://:9092,CONTROLLER://:9093
+        inter.broker.listener.name=PLAINTEXT
+        advertised.listeners=PLAINTEXT://controller3:9092
+        controller.listener.names=CONTROLLER
+        log.dirs=/tmp/kraft-combined-logs
+        s3.data.buckets=0@s3://automq-data?region=us-east-1&endpoint=http://minio:9000&pathStyle=true
+        s3.ops.buckets=1@s3://automq-ops?region=us-east-1&endpoint=http://minio:9000&pathStyle=true
+        s3.wal.path=0@s3://automq-data?region=us-east-1&endpoint=http://minio:9000&pathStyle=true
+        num.partitions=1
+        offsets.topic.replication.factor=1
+        transaction.state.log.replication.factor=1
+        transaction.state.log.min.isr=1
+        EOF
+        /opt/automq/kafka/bin/kafka-storage.sh format -t "$$CLUSTER_ID" -c /tmp/server.properties --ignore-formatted || true
+        exec /opt/automq/kafka/bin/kafka-server-start.sh /tmp/server.properties
+    ports:
+      - "39092:9092"
+    networks:
+      automq_net:
+    depends_on:
+      minio:
+        condition: service_healthy
+      mc:
+        condition: service_started
+
+networks:
+  automq_net:
+    name: automq_net
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: "10.6.0.0/16"
+          gateway: "10.6.0.1"
+DOCKER_COMPOSE_EOF
+print_success "Generated docker-compose.yaml"
+
+# Generate verify.sh
+cat > verify.sh << 'VERIFY_EOF'
+#!/bin/bash
+# AutoMQ Software Verification Script
+set -e
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+print_step() { echo -e "${BLUE}==>${NC} $1"; }
+print_success() { echo -e "${GREEN}✓${NC} $1"; }
+print_error() { echo -e "${RED}✗${NC} $1"; }
+
+echo ""
+echo "╔══════════════════════════════════════════════════════════════╗"
+echo "║         AutoMQ Software - Cluster Verification               ║"
+echo "╚══════════════════════════════════════════════════════════════╝"
+echo ""
+
+print_step "Step 1/4: Checking container status..."
+MINIO_STATUS=$(docker ps --filter "name=minio" --filter "status=running" --format "{{.Names}}" | wc -l | tr -d ' ')
+CONTROLLER_COUNT=$(docker ps --filter "name=automq-controller" --filter "status=running" --format "{{.Names}}" | wc -l | tr -d ' ')
+[ "$MINIO_STATUS" -ge 1 ] && print_success "MinIO is running" || { print_error "MinIO is not running"; exit 1; }
+[ "$CONTROLLER_COUNT" -ge 3 ] && print_success "All 3 AutoMQ controllers are running" || { print_error "Only $CONTROLLER_COUNT/3 controllers are running"; exit 1; }
+echo ""
+
+print_step "Step 2/4: Checking MinIO buckets..."
+docker exec mc /usr/bin/mc ls minio/automq-data > /dev/null 2>&1 && print_success "automq-data bucket exists" || print_error "automq-data bucket not found"
+docker exec mc /usr/bin/mc ls minio/automq-ops > /dev/null 2>&1 && print_success "automq-ops bucket exists" || print_error "automq-ops bucket not found"
+echo ""
+
+print_step "Step 3/4: Creating test topic..."
+docker exec automq-controller1 /opt/automq/kafka/bin/kafka-topics.sh --bootstrap-server controller1:9092 --create --topic test-topic --partitions 3 --replication-factor 1 --if-not-exists 2>/dev/null
+print_success "Test topic created (test-topic)"
+echo ""
+
+print_step "Step 4/4: Listing cluster topics..."
+echo ""
+docker exec automq-controller1 /opt/automq/kafka/bin/kafka-topics.sh --bootstrap-server controller1:9092 --list
+echo ""
+echo "╔══════════════════════════════════════════════════════════════╗"
+echo "║                  Verification Complete                        ║"
+echo "╚══════════════════════════════════════════════════════════════╝"
+echo ""
+echo "  The AutoMQ cluster is healthy and ready to use."
+echo ""
+VERIFY_EOF
 chmod +x verify.sh
-print_success "Downloaded verify.sh"
+print_success "Generated verify.sh"
 
-curl -sSL -o cleanup.sh "${GITHUB_RAW_BASE}/cleanup.sh"
+# Generate cleanup.sh
+cat > cleanup.sh << 'CLEANUP_EOF'
+#!/bin/bash
+# AutoMQ Software Cleanup Script
+set -e
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+print_step() { echo -e "${BLUE}==>${NC} $1"; }
+print_success() { echo -e "${GREEN}✓${NC} $1"; }
+print_warning() { echo -e "${YELLOW}!${NC} $1"; }
+
+echo ""
+echo "╔══════════════════════════════════════════════════════════════╗"
+echo "║           AutoMQ Software - Cluster Cleanup                  ║"
+echo "╚══════════════════════════════════════════════════════════════╝"
+echo ""
+
+read -p "This will remove all AutoMQ containers and data. Continue? [y/N] " -n 1 -r
+echo ""
+[[ ! $REPLY =~ ^[Yy]$ ]] && { print_warning "Cleanup cancelled"; exit 0; }
+echo ""
+
+print_step "Step 1/3: Stopping and removing containers..."
+docker compose down -v 2>/dev/null || docker-compose down -v
+print_success "Containers stopped and removed"
+echo ""
+
+print_step "Step 2/3: Removing network..."
+docker network rm automq_net 2>/dev/null || true
+print_success "Network removed"
+echo ""
+
+print_step "Step 3/3: Cleaning up resources..."
+docker volume prune -f --filter "label=com.docker.compose.project=docker-compose" 2>/dev/null || true
+print_success "Resources cleaned up"
+echo ""
+echo "╔══════════════════════════════════════════════════════════════╗"
+echo "║                    Cleanup Complete                           ║"
+echo "╚══════════════════════════════════════════════════════════════╝"
+echo ""
+CLEANUP_EOF
 chmod +x cleanup.sh
-print_success "Downloaded cleanup.sh"
+print_success "Generated cleanup.sh"
 
 echo ""
 

--- a/software-examples/docker-compose/install.sh
+++ b/software-examples/docker-compose/install.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # AutoMQ Software Docker Compose Installation Script
+# Supports: curl -sSL https://raw.githubusercontent.com/AutoMQ/automq-labs/main/software-examples/docker-compose/install.sh | bash
 
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR"
+# GitHub raw URL base
+GITHUB_RAW_BASE="https://raw.githubusercontent.com/AutoMQ/automq-labs/main/software-examples/docker-compose"
 
 # Colors for output
 RED='\033[0;31m'
@@ -31,12 +32,12 @@ print_error() {
 
 echo ""
 echo "╔══════════════════════════════════════════════════════════════╗"
-echo "║         AutoMQ Software - Docker Compose Setup             ║"
+echo "║         AutoMQ Software - Docker Compose Setup               ║"
 echo "╚══════════════════════════════════════════════════════════════╝"
 echo ""
 
 # Step 1: Prerequisites Check
-print_step "Step 1/4: Checking prerequisites..."
+print_step "Step 1/5: Checking prerequisites..."
 
 if ! command -v docker &> /dev/null; then
     print_error "Docker is not installed. Please install Docker first."
@@ -56,10 +57,32 @@ if ! command -v docker-compose &> /dev/null && ! docker compose version &> /dev/
 fi
 print_success "Docker Compose is available"
 
+if ! command -v curl &> /dev/null; then
+    print_error "curl is not installed. Please install curl first."
+    exit 1
+fi
+print_success "curl is available"
+
 echo ""
 
-# Step 2: Pull Images
-print_step "Step 2/4: Pulling container images..."
+# Step 2: Download required files
+print_step "Step 2/5: Downloading configuration files..."
+
+curl -sSL -o docker-compose.yaml "${GITHUB_RAW_BASE}/docker-compose.yaml"
+print_success "Downloaded docker-compose.yaml"
+
+curl -sSL -o verify.sh "${GITHUB_RAW_BASE}/verify.sh"
+chmod +x verify.sh
+print_success "Downloaded verify.sh"
+
+curl -sSL -o cleanup.sh "${GITHUB_RAW_BASE}/cleanup.sh"
+chmod +x cleanup.sh
+print_success "Downloaded cleanup.sh"
+
+echo ""
+
+# Step 3: Pull Images
+print_step "Step 3/5: Pulling container images..."
 print_warning "This may take a few minutes on first run..."
 
 docker compose pull 2>/dev/null || docker-compose pull
@@ -67,16 +90,16 @@ print_success "Images pulled successfully"
 
 echo ""
 
-# Step 3: Start Services
-print_step "Step 3/4: Starting AutoMQ cluster..."
+# Step 4: Start Services
+print_step "Step 4/5: Starting AutoMQ cluster..."
 
 docker compose up -d 2>/dev/null || docker-compose up -d
 print_success "Services started"
 
 echo ""
 
-# Step 4: Wait for cluster to be ready
-print_step "Step 4/4: Waiting for cluster to be ready..."
+# Step 5: Wait for cluster to be ready
+print_step "Step 5/5: Waiting for cluster to be ready..."
 
 MAX_RETRIES=60
 RETRY_COUNT=0

--- a/software-examples/kubernetes/local/helm/install.sh
+++ b/software-examples/kubernetes/local/helm/install.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # AutoMQ Software Kubernetes Helm Installation Script
-# Supports: curl -sSL https://raw.githubusercontent.com/AutoMQ/automq-examples/main/software-examples/kubernetes/local/helm/install.sh | bash
+# Supports: curl -sSL https://raw.githubusercontent.com/AutoMQ/automq-labs/main/software-examples/kubernetes/local/helm/install.sh | bash
 
 set -e
 
 # GitHub raw URL base
-GITHUB_RAW_BASE="https://raw.githubusercontent.com/AutoMQ/automq-examples/main/software-examples/kubernetes/local/helm"
+GITHUB_RAW_BASE="https://raw.githubusercontent.com/AutoMQ/automq-labs/main/software-examples/kubernetes/local/helm"
 
 # Configuration
 AUTOMQ_VERSION="5.3.4"

--- a/software-examples/kubernetes/local/helm/install.sh
+++ b/software-examples/kubernetes/local/helm/install.sh
@@ -4,9 +4,6 @@
 
 set -e
 
-# GitHub raw URL base
-GITHUB_RAW_BASE="https://raw.githubusercontent.com/AutoMQ/automq-labs/main/software-examples/kubernetes/local/helm"
-
 # Configuration
 AUTOMQ_VERSION="5.3.4"
 MINIO_USER="admin"
@@ -20,27 +17,15 @@ BLUE='\033[0;34m'
 CYAN='\033[0;36m'
 NC='\033[0m'
 
-print_info() {
-    printf "${GREEN}[INFO]${NC} %s\n" "$1"
-}
-
-print_warn() {
-    printf "${YELLOW}[WARN]${NC} %s\n" "$1"
-}
-
-print_error() {
-    printf "${RED}[ERROR]${NC} %s\n" "$1"
-}
-
+print_info() { printf "${GREEN}[INFO]${NC} %s\n" "$1"; }
+print_warn() { printf "${YELLOW}[WARN]${NC} %s\n" "$1"; }
+print_error() { printf "${RED}[ERROR]${NC} %s\n" "$1"; }
 print_step() {
     printf "\n${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
     printf "${CYAN}[STEP %s]${NC} %s\n" "$1" "$2"
     printf "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n\n"
 }
-
-print_config() {
-    printf "  ${CYAN}%-25s${NC} %s\n" "$1:" "$2"
-}
+print_config() { printf "  ${CYAN}%-25s${NC} %s\n" "$1:" "$2"; }
 
 print_header() {
     echo ""
@@ -56,45 +41,28 @@ print_summary() {
     printf "${BLUE}╚══════════════════════════════════════════════════════════════╝${NC}\n\n"
 }
 
-# Step 1: Check prerequisites
 check_prerequisites() {
     print_step "1/6" "Checking Prerequisites"
-    
     local has_error=0
 
-    # Check curl
-    printf "  Checking curl... "
-    if ! command -v curl &> /dev/null; then
+    printf "  Checking kubectl... "
+    if ! command -v kubectl &> /dev/null; then
         printf "${RED}NOT FOUND${NC}\n"
-        print_error "curl is not installed."
+        print_error "kubectl is not installed."
         has_error=1
     else
         printf "${GREEN}OK${NC}\n"
     fi
 
-    # Check kubectl
-    printf "  Checking kubectl... "
-    if ! command -v kubectl &> /dev/null; then
-        printf "${RED}NOT FOUND${NC}\n"
-        print_error "kubectl is not installed. Please install kubectl first."
-        print_info "  Installation guide: https://kubernetes.io/docs/tasks/tools/"
-        has_error=1
-    else
-        printf "${GREEN}OK${NC} ($(kubectl version --client --short 2>/dev/null | head -1 || echo "installed"))\n"
-    fi
-
-    # Check helm
     printf "  Checking helm... "
     if ! command -v helm &> /dev/null; then
         printf "${RED}NOT FOUND${NC}\n"
-        print_error "helm is not installed. Please install helm first."
-        print_info "  Installation guide: https://helm.sh/docs/intro/install/"
+        print_error "helm is not installed."
         has_error=1
     else
         printf "${GREEN}OK${NC} ($(helm version --short 2>/dev/null))\n"
     fi
 
-    # Check kubernetes cluster connectivity
     printf "  Checking Kubernetes cluster... "
     if ! kubectl cluster-info &> /dev/null; then
         printf "${RED}NOT ACCESSIBLE${NC}\n"
@@ -106,54 +74,111 @@ check_prerequisites() {
         printf "${GREEN}OK${NC} ($node_count nodes)\n"
     fi
 
-    if [ $has_error -eq 1 ]; then
-        echo ""
-        print_error "Prerequisites check failed. Please resolve the issues above and try again."
-        exit 1
-    fi
-
+    [ $has_error -eq 1 ] && { print_error "Prerequisites check failed."; exit 1; }
     print_info "All prerequisites satisfied!"
 }
 
-# Step 2: Download helper scripts
-download_scripts() {
-    print_step "2/6" "Downloading Helper Scripts"
-    
-    curl -sSL -o verify.sh "${GITHUB_RAW_BASE}/verify.sh"
-    chmod +x verify.sh
-    print_info "✓ Downloaded verify.sh"
+generate_scripts() {
+    print_step "2/6" "Generating Helper Scripts"
 
-    curl -sSL -o cleanup.sh "${GITHUB_RAW_BASE}/cleanup.sh"
+    # Generate verify.sh
+    cat > verify.sh << 'VERIFY_EOF'
+#!/bin/bash
+set -e
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+print_info() { printf "${GREEN}[INFO]${NC} %s\n" "$1"; }
+print_error() { printf "${RED}[ERROR]${NC} %s\n" "$1"; }
+
+echo ""
+echo "=============================================="
+echo " AutoMQ Installation Verification"
+echo "=============================================="
+echo ""
+
+print_info "Checking AutoMQ pods status..."
+ready_pods=$(kubectl get pods -l app.kubernetes.io/name=automq-enterprise --no-headers 2>/dev/null | grep -c "Running" || echo "0")
+total_pods=$(kubectl get pods -l app.kubernetes.io/name=automq-enterprise --no-headers 2>/dev/null | wc -l | tr -d ' ')
+[ "$total_pods" -eq 0 ] && { print_error "No AutoMQ pods found."; exit 1; }
+echo ""
+kubectl get pods -l app.kubernetes.io/name=automq-enterprise
+echo ""
+[ "$ready_pods" -ne "$total_pods" ] && kubectl wait --for=condition=Ready pods -l app.kubernetes.io/name=automq-enterprise --timeout=300s
+print_info "✓ All AutoMQ pods are running"
+
+print_info "Creating test topic..."
+kubectl run kafka-client-test --rm -it --restart=Never --image=confluentinc/cp-kafka:latest --command -- \
+    kafka-topics --bootstrap-server automq-automq-enterprise-controller-headless:9092 \
+    --create --topic test-topic --partitions 3 --replication-factor 1 --if-not-exists
+print_info "✓ Test topic created"
+
+print_info "Listing topics..."
+kubectl run kafka-client-list --rm -it --restart=Never --image=confluentinc/cp-kafka:latest --command -- \
+    kafka-topics --bootstrap-server automq-automq-enterprise-controller-headless:9092 --list
+
+echo ""
+echo "=============================================="
+echo " Verification Complete!"
+echo "=============================================="
+echo ""
+VERIFY_EOF
+    chmod +x verify.sh
+    print_info "✓ Generated verify.sh"
+
+    # Generate cleanup.sh
+    cat > cleanup.sh << 'CLEANUP_EOF'
+#!/bin/bash
+set -e
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+print_info() { printf "${GREEN}[INFO]${NC} %s\n" "$1"; }
+print_warn() { printf "${YELLOW}[WARN]${NC} %s\n" "$1"; }
+
+echo ""
+echo "=============================================="
+echo " AutoMQ Cleanup"
+echo "=============================================="
+echo ""
+
+printf "This will remove AutoMQ and MinIO. Continue? [y/N] "
+read -r REPLY
+[[ ! "$REPLY" =~ ^[Yy] ]] && { print_info "Cleanup cancelled."; exit 0; }
+echo ""
+
+print_info "Removing AutoMQ..."
+helm status automq &> /dev/null && helm uninstall automq && print_info "✓ AutoMQ removed" || print_warn "AutoMQ not found"
+kubectl delete pvc -l app.kubernetes.io/name=automq-enterprise 2>/dev/null || true
+
+print_info "Removing MinIO..."
+helm status minio &> /dev/null && helm uninstall minio && print_info "✓ MinIO removed" || print_warn "MinIO not found"
+kubectl delete pvc -l app=minio 2>/dev/null || true
+
+[ -f "automq-values.yaml" ] && rm -f automq-values.yaml && print_info "✓ automq-values.yaml removed"
+
+echo ""
+echo "=============================================="
+echo " Cleanup Complete!"
+echo "=============================================="
+echo ""
+CLEANUP_EOF
     chmod +x cleanup.sh
-    print_info "✓ Downloaded cleanup.sh"
+    print_info "✓ Generated cleanup.sh"
 }
 
-# Step 3: Detect architecture and generate values
 generate_values() {
     print_step "3/6" "Generating Configuration"
     
-    # Detect CPU architecture
-    local arch
-    arch=$(uname -m)
+    local arch=$(uname -m)
     case $arch in
-        arm64|aarch64)
-            NODE_ARCH="arm64"
-            ;;
-        x86_64|amd64)
-            NODE_ARCH="amd64"
-            ;;
-        *)
-            NODE_ARCH="amd64"
-            ;;
+        arm64|aarch64) NODE_ARCH="arm64" ;;
+        *) NODE_ARCH="amd64" ;;
     esac
     
     print_info "Detected CPU architecture: $NODE_ARCH"
-    print_info "Generating automq-values.yaml..."
     
-    cat <<EOF > automq-values.yaml
-# AutoMQ Helm Values - Generated by install.sh
-# Architecture: ${NODE_ARCH}
-
+    cat > automq-values.yaml << EOF
 global:
   automqInstanceId: "automq-demo-cluster"
   cloudProvider:
@@ -199,41 +224,21 @@ broker:
     wal:
       enabled: false
 EOF
-
-    print_info "✓ Configuration file generated"
-    echo ""
-    echo "  Configuration summary:"
+    print_info "✓ Generated automq-values.yaml"
     print_config "Architecture" "$NODE_ARCH"
     print_config "Controller Replicas" "3"
-    print_config "Controller Memory" "2Gi - 4Gi"
-    print_config "Controller CPU" "1 - 2 cores"
-    print_config "Heap Size" "2GB"
 }
 
-# Step 4: Install MinIO
 install_minio() {
-    print_step "4/6" "Installing MinIO (Object Storage)"
+    print_step "4/6" "Installing MinIO"
     
-    # Add helm repo
-    print_info "Adding MinIO helm repository..."
     helm repo add minio https://charts.min.io/ > /dev/null 2>&1 || true
     helm repo update > /dev/null 2>&1
     
-    # Check if already installed
     if helm status minio &> /dev/null; then
-        print_warn "MinIO is already installed, skipping..."
+        print_warn "MinIO already installed, skipping..."
         return
     fi
-    
-    echo ""
-    echo "  MinIO configuration:"
-    print_config "Root User" "$MINIO_USER"
-    print_config "Root Password" "$MINIO_PASSWORD"
-    print_config "Data Bucket" "automq-data"
-    print_config "Ops Bucket" "automq-ops"
-    print_config "Mode" "standalone"
-    print_config "Persistence" "disabled"
-    echo ""
     
     print_info "Installing MinIO..."
     helm install minio minio/minio \
@@ -248,42 +253,26 @@ install_minio() {
         --set resources.requests.cpu=250m \
         --set resources.limits.memory=2Gi \
         --set resources.limits.cpu=2 \
-        --wait \
-        --timeout 5m \
-        > /dev/null
-    
-    print_info "✓ MinIO installed successfully"
+        --wait --timeout 5m > /dev/null
+    print_info "✓ MinIO installed"
 }
 
-# Step 5: Install AutoMQ
 install_automq() {
     print_step "5/6" "Installing AutoMQ"
     
-    # Check if already installed
     if helm status automq &> /dev/null; then
-        print_warn "AutoMQ is already installed, skipping..."
+        print_warn "AutoMQ already installed, skipping..."
         return
     fi
-    
-    echo ""
-    echo "  AutoMQ configuration:"
-    print_config "Version" "$AUTOMQ_VERSION"
-    print_config "Chart" "oci://automq.azurecr.io/helm/automq-enterprise-chart"
-    print_config "Values File" "automq-values.yaml"
-    echo ""
     
     print_info "Installing AutoMQ (this may take a few minutes)..."
     helm install automq oci://automq.azurecr.io/helm/automq-enterprise-chart \
         --version "$AUTOMQ_VERSION" \
         -f automq-values.yaml \
-        --wait \
-        --timeout 10m \
-        > /dev/null
-    
-    print_info "✓ AutoMQ installed successfully"
+        --wait --timeout 10m > /dev/null
+    print_info "✓ AutoMQ installed"
 }
 
-# Step 6: Verify installation
 verify_installation() {
     print_step "6/6" "Verifying Installation"
     
@@ -292,55 +281,27 @@ verify_installation() {
     kubectl get pods -l app.kubernetes.io/name=automq-enterprise
     echo ""
     
-    # Wait for pods to be ready
-    local ready_pods
-    local total_pods
     ready_pods=$(kubectl get pods -l app.kubernetes.io/name=automq-enterprise --no-headers 2>/dev/null | grep -c "Running" || echo "0")
     total_pods=$(kubectl get pods -l app.kubernetes.io/name=automq-enterprise --no-headers 2>/dev/null | wc -l | tr -d ' ')
     
-    if [ "$ready_pods" -ne "$total_pods" ]; then
-        print_info "Waiting for all pods to be ready..."
-        kubectl wait --for=condition=Ready pods -l app.kubernetes.io/name=automq-enterprise --timeout=300s
-    fi
-    
+    [ "$ready_pods" -ne "$total_pods" ] && kubectl wait --for=condition=Ready pods -l app.kubernetes.io/name=automq-enterprise --timeout=300s
     print_info "✓ All AutoMQ pods are running"
 }
 
-# Print final summary
 print_final_summary() {
     print_summary
-    
-    echo "  Deployed components:"
-    print_config "MinIO" "Running (standalone mode)"
-    print_config "AutoMQ Controllers" "3 replicas"
+    echo "  Bootstrap Server: automq-automq-enterprise-controller-headless:9092"
     echo ""
-    
-    echo "  Access information:"
-    print_config "Bootstrap Server" "automq-automq-enterprise-controller-headless:9092"
-    print_config "MinIO Console" "kubectl port-forward svc/minio-console 9001:9001"
-    echo ""
-    
-    echo "  Quick test commands:"
-    echo ""
-    echo "  # Create a topic"
-    echo "  kubectl run kafka-client --rm -it --restart=Never --image=confluentinc/cp-kafka:latest -- \\"
-    echo "    kafka-topics --bootstrap-server automq-automq-enterprise-controller-headless:9092 \\"
-    echo "    --create --topic test-topic --partitions 3 --replication-factor 1"
-    echo ""
-    echo "  # List topics"
-    echo "  kubectl run kafka-list --rm -it --restart=Never --image=confluentinc/cp-kafka:latest -- \\"
-    echo "    kafka-topics --bootstrap-server automq-automq-enterprise-controller-headless:9092 --list"
-    echo ""
-    echo "  Cleanup:"
-    echo "  ./cleanup.sh"
+    echo "  Next Steps:"
+    echo "    ./verify.sh  - Test the cluster"
+    echo "    ./cleanup.sh - Remove the cluster"
     echo ""
 }
 
-# Main
 main() {
     print_header
     check_prerequisites
-    download_scripts
+    generate_scripts
     generate_values
     install_minio
     install_automq


### PR DESCRIPTION
## Summary
Fix installation scripts to support `curl | bash` workflow by embedding all helper scripts inline instead of downloading from GitHub.

## Changes
- **docker-compose/install.sh**: Embed `docker-compose.yaml`, `verify.sh`, `cleanup.sh` inline
- **kubernetes/local/helm/install.sh**: Embed `verify.sh`, `cleanup.sh`, `automq-values.yaml` inline  
- **binary/setup.sh**: Embed `format-storage.sh`, `verify.sh`, `cleanup.sh`, `minio/docker-compose.yml` inline

## Benefits
- No dependency on GitHub file downloads during installation
- Self-contained scripts - single curl command completes all setup
- Easier maintenance with all content in one file

## Testing
All three deployment modes verified locally:
- ✅ Docker Compose - 3 controllers started, verify.sh passed, cleanup.sh passed
- ✅ Helm Chart (Kubernetes) - MinIO + AutoMQ installed, verify.sh passed, cleanup.sh passed
- ✅ Binary - MinIO + 3 nodes started, verify.sh passed, cleanup.sh passed