### PR TITLE
feat: Add AutoMQ Strimzi deployment scripts for AWS EKS

### DIFF
--- a/byoc-examples/setup/kubernetes/aws/terraform/terraform.tfvars.example
+++ b/byoc-examples/setup/kubernetes/aws/terraform/terraform.tfvars.example
@@ -1,0 +1,11 @@
+region          = "us-east-1"
+resource_suffix = "automq"
+
+node_group = {
+  name          = "automq-nodes"
+  desired_size  = 3
+  max_size      = 5
+  min_size      = 3
+  instance_type = "r6i.large"
+  ami_type      = "AL2_x86_64"
+}

--- a/software-examples/strimzi/README.md
+++ b/software-examples/strimzi/README.md
@@ -1,0 +1,332 @@
+# Deploy AutoMQ on AWS EKS with Strimzi
+
+This guide provides step-by-step instructions for deploying AutoMQ on AWS EKS using the Strimzi Kafka Operator.
+
+## Prerequisites
+
+### 1. AWS EKS Cluster
+
+You need an AWS EKS cluster with the following requirements:
+
+- **Kubernetes Version**: 1.28+
+- **Node Instance Type**: `r6i.large` or larger (16GB+ memory required)
+- **Node Count**: At least 3 nodes for high availability
+- **Storage Class**: `gp2` or `gp3` available
+
+To provision an EKS cluster, follow our Terraform guide:
+👉 [Terraform for AutoMQ on AWS EKS](../../../byoc-examples/setup/kubernetes/aws/terraform/README.md)
+
+### 2. Tools
+
+Ensure you have the following tools installed:
+
+```bash
+# Verify kubectl
+kubectl version --client
+
+# Verify helm
+helm version
+
+# Verify AWS CLI
+aws --version
+```
+
+### 3. S3 Buckets
+
+Create two S3 buckets for AutoMQ data storage:
+
+```bash
+# Set your AWS region
+export AWS_REGION=us-east-1
+
+# Create unique bucket names (add a random suffix)
+export BUCKET_SUFFIX=$(date +%s)
+export DATA_BUCKET="automq-data-${BUCKET_SUFFIX}"
+export OPS_BUCKET="automq-ops-${BUCKET_SUFFIX}"
+
+# Create buckets
+aws s3 mb s3://${DATA_BUCKET} --region ${AWS_REGION}
+aws s3 mb s3://${OPS_BUCKET} --region ${AWS_REGION}
+
+echo "Data Bucket: ${DATA_BUCKET}"
+echo "Ops Bucket: ${OPS_BUCKET}"
+```
+
+### 4. IAM Permissions
+
+The EKS node group needs S3 access permissions. If you used our Terraform setup, the IAM role is already configured. Otherwise, attach the following policy to your node group IAM role:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::automq-*",
+        "arn:aws:s3:::automq-*/*"
+      ]
+    }
+  ]
+}
+```
+
+## Installation
+
+### Step 1: Pre-flight Check
+
+Run the pre-flight check to verify your cluster meets the requirements:
+
+```bash
+./install.sh --check
+```
+
+This will verify:
+- kubectl and helm are installed
+- Cluster connectivity
+- Node instance types (r6i.large or larger)
+- Available memory on nodes
+
+### Step 2: Install Strimzi Operator
+
+```bash
+# Create namespace
+kubectl create namespace automq
+
+# Install Strimzi Operator
+helm install automq-strimzi-operator oci://quay.io/strimzi-helm/strimzi-kafka-operator \
+  --version 0.47.0 \
+  --namespace automq \
+  --values strimzi-values.yaml
+
+# Wait for operator to be ready
+kubectl wait --for=condition=available deployment/strimzi-cluster-operator \
+  -n automq --timeout=120s
+```
+
+### Step 3: Configure AutoMQ Cluster
+
+Edit `automq-cluster.yaml` and replace the S3 bucket placeholders:
+
+```bash
+# Replace placeholders with your bucket names
+sed -i.bak \
+  -e "s|\${OPS_BUCKET}|${OPS_BUCKET}|g" \
+  -e "s|\${DATA_BUCKET}|${DATA_BUCKET}|g" \
+  -e "s|\${AWS_REGION}|${AWS_REGION}|g" \
+  automq-cluster.yaml
+```
+
+Or manually edit the file and update these values:
+- `${OPS_BUCKET}` → your ops bucket name
+- `${DATA_BUCKET}` → your data bucket name  
+- `${AWS_REGION}` → your AWS region (e.g., `us-east-1`)
+
+### Step 4: Deploy AutoMQ Cluster
+
+```bash
+kubectl apply -f automq-cluster.yaml -n automq
+```
+
+### Step 5: Verify Installation
+
+```bash
+# Check pod status
+kubectl get pods -n automq -w
+
+# Run verification script
+./verify.sh
+```
+
+All 3 controller pods should be in `Running` state with `1/1` ready.
+
+## Verification
+
+### Check Cluster Status
+
+```bash
+# View all pods
+kubectl get pods -n automq -o wide
+
+# Check Kafka cluster status
+kubectl get kafka -n automq
+
+# View controller logs
+kubectl logs my-cluster-controller-0 -n automq --tail=50
+```
+
+### Test with Kafka Commands
+
+```bash
+# Get controller pod name
+CONTROLLER_POD=$(kubectl get pods -n automq -l strimzi.io/pool-name=controller \
+  -o jsonpath='{.items[0].metadata.name}')
+
+# Create a test topic
+kubectl exec -n automq $CONTROLLER_POD -- /opt/kafka/bin/kafka-topics.sh \
+  --bootstrap-server localhost:9092 \
+  --create --topic test-topic --partitions 3 --replication-factor 1
+
+# List topics
+kubectl exec -n automq $CONTROLLER_POD -- /opt/kafka/bin/kafka-topics.sh \
+  --bootstrap-server localhost:9092 --list
+
+# Produce messages (interactive)
+kubectl exec -it -n automq $CONTROLLER_POD -- /opt/kafka/bin/kafka-console-producer.sh \
+  --bootstrap-server localhost:9092 --topic test-topic
+
+# Consume messages
+kubectl exec -it -n automq $CONTROLLER_POD -- /opt/kafka/bin/kafka-console-consumer.sh \
+  --bootstrap-server localhost:9092 --topic test-topic --from-beginning
+```
+
+## Configuration
+
+### Default Settings
+
+| Component | Setting | Value |
+|-----------|---------|-------|
+| Namespace | Name | automq |
+| Strimzi | Version | 0.47.0 |
+| AutoMQ | Version | 1.6.0-strimzi |
+| Kafka | Version | 3.9.0 |
+| Controller | Replicas | 3 |
+| Controller | Memory Request | 12Gi |
+| Controller | Memory Limit | 16Gi |
+| Controller | CPU Request | 1000m |
+| Controller | CPU Limit | 2000m |
+| JVM | Heap | 6GB |
+| JVM | Direct Memory | 6GB |
+| Storage | Size | 20Gi |
+
+### Node Requirements
+
+AutoMQ requires nodes with sufficient memory. The configuration enforces scheduling only on supported instance types:
+
+- `r6i.large` (16GB RAM) - minimum recommended
+- `r6i.xlarge` (32GB RAM)
+- `r6i.2xlarge` (64GB RAM)
+- `r6in.large` (16GB RAM)
+- `r6in.xlarge` (32GB RAM)
+- `r6in.2xlarge` (64GB RAM)
+
+### Pod Anti-Affinity
+
+The configuration includes pod anti-affinity rules to ensure each controller/broker runs on a separate node for high availability.
+
+## Cleanup
+
+### Remove AutoMQ Cluster
+
+```bash
+# Delete AutoMQ cluster
+kubectl delete -f automq-cluster.yaml -n automq
+
+# Wait for pods to terminate
+kubectl wait --for=delete pod -l strimzi.io/cluster=my-cluster -n automq --timeout=120s
+
+# Delete PVCs (optional - removes all data)
+kubectl delete pvc -l strimzi.io/cluster=my-cluster -n automq
+```
+
+### Remove Strimzi Operator
+
+```bash
+helm uninstall automq-strimzi-operator -n automq
+```
+
+### Remove Namespace
+
+```bash
+kubectl delete namespace automq
+```
+
+### Remove S3 Buckets (Optional)
+
+```bash
+# Empty and delete buckets
+aws s3 rb s3://${DATA_BUCKET} --force
+aws s3 rb s3://${OPS_BUCKET} --force
+```
+
+## Troubleshooting
+
+### Pods Stuck in Pending
+
+Check if nodes meet the instance type requirements:
+
+```bash
+kubectl get nodes -o custom-columns=NAME:.metadata.name,TYPE:.metadata.labels."node\.kubernetes\.io/instance-type"
+```
+
+### OOMKilled Errors
+
+Ensure nodes have at least 16GB memory. Check pod resource usage:
+
+```bash
+kubectl describe pod my-cluster-controller-0 -n automq | grep -A 10 "Last State"
+```
+
+### S3 Access Denied
+
+Verify IAM permissions:
+
+```bash
+# Check if pods can access S3
+kubectl exec -n automq my-cluster-controller-0 -- \
+  aws s3 ls s3://${DATA_BUCKET}/ 2>&1 | head -5
+```
+
+### Strimzi Operator Issues
+
+Check operator logs:
+
+```bash
+kubectl logs -l name=strimzi-cluster-operator -n automq --tail=100
+```
+
+If the operator is stuck, restart it:
+
+```bash
+kubectl rollout restart deployment strimzi-cluster-operator -n automq
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     AWS EKS Cluster                              │
+│                     (automq namespace)                           │
+│                                                                  │
+│  ┌──────────────────┐                                            │
+│  │ Strimzi Operator │                                            │
+│  └────────┬─────────┘                                            │
+│           │ manages                                              │
+│           ▼                                                      │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐              │
+│  │ controller-0│  │ controller-1│  │ controller-2│              │
+│  │ (KRaft +    │  │ (KRaft +    │  │ (KRaft +    │              │
+│  │  Broker)    │  │  Broker)    │  │  Broker)    │              │
+│  └──────┬──────┘  └──────┬──────┘  └──────┬──────┘              │
+│         │                │                │                      │
+│         └────────────────┼────────────────┘                      │
+│                          │                                       │
+│                    ┌─────┴─────┐                                 │
+│                    │  AWS S3   │                                 │
+│                    │ (data +   │                                 │
+│                    │   ops)    │                                 │
+│                    └───────────┘                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## References
+
+- [AutoMQ Documentation](https://www.automq.com/docs/automq)
+- [Strimzi Documentation](https://strimzi.io/documentation/)
+- [AWS EKS Documentation](https://docs.aws.amazon.com/eks/)

--- a/software-examples/strimzi/automq-cluster.yaml
+++ b/software-examples/strimzi/automq-cluster.yaml
@@ -1,0 +1,96 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: controller
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - controller
+    - broker
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 20Gi
+        kraftMetadata: shared
+        deleteClaim: false
+        class: gp2
+  resources:
+    requests:
+      cpu: 1000m
+      memory: 12Gi
+    limits:
+      cpu: 2000m
+      memory: 16Gi
+  template:
+    pod:
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "automq"
+          effect: "NoSchedule"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: In
+                    values:
+                      - r6i.large
+                      - r6i.xlarge
+                      - r6i.2xlarge
+                      - r6in.large
+                      - r6in.xlarge
+                      - r6in.2xlarge
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: strimzi.io/component-type
+                    operator: In
+                    values:
+                      - kafka
+              topologyKey: kubernetes.io/hostname
+    kafkaContainer:
+      env:
+        - name: "KAFKA_HEAP_OPTS"
+          value: "-Xmx6g -Xms6g -XX:MaxDirectMemorySize=6g -XX:MetaspaceSize=96m"
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: my-cluster
+  annotations:
+    strimzi.io/node-pools: enabled
+    strimzi.io/kraft: enabled
+    strimzi.io/skip-broker-scaledown-check: "true"
+spec:
+  kafka:
+    version: 3.9.0
+    metadataVersion: 3.9-IV0
+    listeners:
+      - name: plain1
+        port: 9092
+        type: internal
+        tls: false
+      - name: plain2
+        port: 9093
+        type: internal
+        tls: false
+    config:
+      elasticstream.enable: true
+      # Replace the following with your bucket config.
+      s3.ops.buckets: "1@s3://${OPS_BUCKET}?region=${AWS_REGION}"
+      s3.data.buckets: "0@s3://${DATA_BUCKET}?region=${AWS_REGION}"
+      s3.wal.path: "0@s3://${DATA_BUCKET}?region=${AWS_REGION}"
+      automq.zonerouter.channels: "0@s3://${DATA_BUCKET}?region=${AWS_REGION}"
+      autobalancer.client.listener.name: PLAIN1-9092
+    rack:
+      topologyKey: topology.kubernetes.io/zone
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}

--- a/software-examples/strimzi/cleanup.sh
+++ b/software-examples/strimzi/cleanup.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# AutoMQ Strimzi Cleanup Script
+# Usage: ./cleanup.sh [--force]
+
+set -e
+
+NAMESPACE="${NAMESPACE:-automq}"
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+print_info() { printf "${GREEN}[INFO]${NC} %s\n" "$1"; }
+print_warn() { printf "${YELLOW}[WARN]${NC} %s\n" "$1"; }
+
+FORCE=false
+[[ "${1:-}" == "--force" || "${1:-}" == "-f" ]] && FORCE=true
+
+echo ""
+echo "=============================================="
+echo " AutoMQ Strimzi Cleanup"
+echo "=============================================="
+echo ""
+
+if [ "$FORCE" != true ]; then
+    printf "This will remove AutoMQ and Strimzi from namespace '$NAMESPACE'. Continue? [y/N] "
+    read -r REPLY
+    [[ ! "$REPLY" =~ ^[Yy] ]] && { print_info "Cleanup cancelled."; exit 0; }
+    echo ""
+fi
+
+print_info "Removing AutoMQ cluster..."
+kubectl delete kafka my-cluster -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+kubectl delete kafkanodepool controller broker -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+print_info "✓ AutoMQ cluster removed"
+
+print_info "Waiting for pods to terminate..."
+kubectl wait --for=delete pods -l strimzi.io/cluster=my-cluster -n "$NAMESPACE" --timeout=120s 2>/dev/null || true
+
+print_info "Removing PVCs..."
+kubectl delete pvc -l strimzi.io/cluster=my-cluster -n "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+print_info "✓ PVCs removed"
+
+print_info "Removing Strimzi Operator..."
+helm uninstall automq-strimzi-operator --namespace "$NAMESPACE" 2>/dev/null || true
+print_info "✓ Strimzi Operator removed"
+
+print_info "Deleting namespace '$NAMESPACE'..."
+kubectl delete namespace "$NAMESPACE" --ignore-not-found=true 2>/dev/null || true
+print_info "✓ Namespace deleted"
+
+echo ""
+echo "=============================================="
+echo " Cleanup Complete!"
+echo "=============================================="
+echo ""
+print_info "Note: S3 buckets are not deleted. Remove them manually if needed:"
+echo "  aws s3 rb s3://YOUR_DATA_BUCKET --force"
+echo "  aws s3 rb s3://YOUR_OPS_BUCKET --force"
+echo ""

--- a/software-examples/strimzi/install.sh
+++ b/software-examples/strimzi/install.sh
@@ -1,0 +1,319 @@
+#!/bin/bash
+# AutoMQ Strimzi Installation Script for AWS EKS
+# Usage: ./install.sh [--check]
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Configuration
+NAMESPACE="${NAMESPACE:-automq}"
+STRIMZI_VERSION="${STRIMZI_VERSION:-0.47.0}"
+AUTOMQ_VERSION="${AUTOMQ_VERSION:-1.6.0-strimzi}"
+KAFKA_VERSION="${KAFKA_VERSION:-3.9.0}"
+
+# Minimum requirements
+MIN_MEMORY_GB=16
+SUPPORTED_INSTANCE_TYPES="r6i.large r6i.xlarge r6i.2xlarge r6in.large r6in.xlarge r6in.2xlarge"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+print_info() { printf "${GREEN}[INFO]${NC} %s\n" "$1"; }
+print_warn() { printf "${YELLOW}[WARN]${NC} %s\n" "$1"; }
+print_error() { printf "${RED}[ERROR]${NC} %s\n" "$1"; }
+print_step() {
+    printf "\n${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+    printf "${CYAN}[STEP %s]${NC} %s\n" "$1" "$2"
+    printf "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n\n"
+}
+print_config() { printf "  ${CYAN}%-25s${NC} %s\n" "$1:" "$2"; }
+
+print_header() {
+    echo ""
+    printf "${BLUE}╔══════════════════════════════════════════════════════════════╗${NC}\n"
+    printf "${BLUE}║${NC}       ${CYAN}AutoMQ Strimzi Deployment on AWS EKS${NC}                  ${BLUE}║${NC}\n"
+    printf "${BLUE}╚══════════════════════════════════════════════════════════════╝${NC}\n"
+    echo ""
+}
+
+check_prerequisites() {
+    print_step "1/4" "Pre-flight Check"
+    local has_error=0
+
+    # Check kubectl
+    printf "  Checking kubectl... "
+    if ! command -v kubectl &> /dev/null; then
+        printf "${RED}NOT FOUND${NC}\n"
+        print_error "kubectl is not installed."
+        has_error=1
+    else
+        printf "${GREEN}OK${NC}\n"
+    fi
+
+    # Check helm
+    printf "  Checking helm... "
+    if ! command -v helm &> /dev/null; then
+        printf "${RED}NOT FOUND${NC}\n"
+        print_error "helm is not installed."
+        has_error=1
+    else
+        printf "${GREEN}OK${NC} ($(helm version --short 2>/dev/null))\n"
+    fi
+
+    # Check cluster connectivity
+    printf "  Checking Kubernetes cluster... "
+    if ! kubectl cluster-info &> /dev/null; then
+        printf "${RED}NOT ACCESSIBLE${NC}\n"
+        print_error "Cannot connect to Kubernetes cluster."
+        has_error=1
+    else
+        local node_count
+        node_count=$(kubectl get nodes --no-headers 2>/dev/null | wc -l | tr -d ' ')
+        printf "${GREEN}OK${NC} ($node_count nodes)\n"
+    fi
+
+    [ $has_error -eq 1 ] && { print_error "Prerequisites check failed."; exit 1; }
+
+    # Check node instance types
+    printf "  Checking node instance types... "
+    local valid_nodes=0
+    local total_nodes=0
+    local invalid_nodes=""
+    
+    while IFS= read -r line; do
+        node_name=$(echo "$line" | awk '{print $1}')
+        instance_type=$(echo "$line" | awk '{print $2}')
+        total_nodes=$((total_nodes + 1))
+        
+        if echo "$SUPPORTED_INSTANCE_TYPES" | grep -qw "$instance_type"; then
+            valid_nodes=$((valid_nodes + 1))
+        else
+            invalid_nodes="$invalid_nodes\n    - $node_name ($instance_type)"
+        fi
+    done < <(kubectl get nodes -o custom-columns=NAME:.metadata.name,TYPE:.metadata.labels."node\.kubernetes\.io/instance-type" --no-headers 2>/dev/null)
+
+    if [ $valid_nodes -ge 3 ]; then
+        printf "${GREEN}OK${NC} ($valid_nodes/$total_nodes nodes with supported instance types)\n"
+    else
+        printf "${RED}INSUFFICIENT${NC}\n"
+        print_error "Need at least 3 nodes with supported instance types."
+        print_error "Supported types: $SUPPORTED_INSTANCE_TYPES"
+        if [ -n "$invalid_nodes" ]; then
+            print_error "Nodes with unsupported types:$invalid_nodes"
+        fi
+        print_error ""
+        print_error "Please provision an EKS cluster with r6i.large or larger instances."
+        print_error "See: byoc-examples/setup/kubernetes/aws/terraform/README.md"
+        has_error=1
+    fi
+
+    # Check node memory
+    printf "  Checking node memory... "
+    local low_memory_nodes=""
+    while IFS= read -r line; do
+        node_name=$(echo "$line" | awk '{print $1}')
+        allocatable_mem=$(echo "$line" | awk '{print $2}')
+        
+        # Convert to GB (handle Ki, Mi, Gi suffixes)
+        if [[ "$allocatable_mem" == *"Ki" ]]; then
+            mem_gb=$(echo "$allocatable_mem" | sed 's/Ki//' | awk '{printf "%.0f", $1/1024/1024}')
+        elif [[ "$allocatable_mem" == *"Mi" ]]; then
+            mem_gb=$(echo "$allocatable_mem" | sed 's/Mi//' | awk '{printf "%.0f", $1/1024}')
+        elif [[ "$allocatable_mem" == *"Gi" ]]; then
+            mem_gb=$(echo "$allocatable_mem" | sed 's/Gi//')
+        else
+            mem_gb=0
+        fi
+        
+        if [ "$mem_gb" -lt "$MIN_MEMORY_GB" ] 2>/dev/null; then
+            low_memory_nodes="$low_memory_nodes\n    - $node_name (${allocatable_mem})"
+        fi
+    done < <(kubectl get nodes -o custom-columns=NAME:.metadata.name,MEM:.status.allocatable.memory --no-headers 2>/dev/null)
+
+    if [ -z "$low_memory_nodes" ]; then
+        printf "${GREEN}OK${NC} (all nodes have >= ${MIN_MEMORY_GB}GB)\n"
+    else
+        printf "${YELLOW}WARNING${NC}\n"
+        print_warn "Some nodes have less than ${MIN_MEMORY_GB}GB memory:$low_memory_nodes"
+        print_warn "AutoMQ pods will not be scheduled on these nodes."
+    fi
+
+    # Check zone labels
+    printf "  Checking zone labels... "
+    local nodes_without_zone
+    nodes_without_zone=$(kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.metadata.labels.topology\.kubernetes\.io/zone}{"\n"}{end}' 2>/dev/null | grep -E "^\S+\s*$" | wc -l | tr -d ' ')
+
+    if [ "$nodes_without_zone" -gt 0 ]; then
+        printf "${YELLOW}MISSING${NC}\n"
+        print_warn "Some nodes are missing topology.kubernetes.io/zone label"
+    else
+        printf "${GREEN}OK${NC}\n"
+    fi
+
+    [ $has_error -eq 1 ] && { print_error "Pre-flight check failed."; exit 1; }
+    
+    print_info "All pre-flight checks passed!"
+}
+
+install_strimzi() {
+    print_step "2/4" "Installing Strimzi Operator"
+    
+    # Create namespace
+    kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f - > /dev/null 2>&1
+    
+    if helm status automq-strimzi-operator -n "$NAMESPACE" &> /dev/null; then
+        print_warn "Strimzi Operator already installed, upgrading..."
+        helm upgrade automq-strimzi-operator oci://quay.io/strimzi-helm/strimzi-kafka-operator \
+            --version "$STRIMZI_VERSION" \
+            --namespace "$NAMESPACE" \
+            --values strimzi-values.yaml \
+            --wait --timeout 5m > /dev/null
+    else
+        print_info "Installing Strimzi Operator..."
+        helm install automq-strimzi-operator oci://quay.io/strimzi-helm/strimzi-kafka-operator \
+            --version "$STRIMZI_VERSION" \
+            --namespace "$NAMESPACE" \
+            --values strimzi-values.yaml \
+            --wait --timeout 5m > /dev/null
+    fi
+    print_info "✓ Strimzi Operator installed"
+}
+
+check_s3_config() {
+    print_step "3/4" "Checking S3 Configuration"
+    
+    # Check if automq-cluster.yaml has placeholder values
+    if grep -q '\${OPS_BUCKET}\|\${DATA_BUCKET}\|\${AWS_REGION}' automq-cluster.yaml 2>/dev/null; then
+        print_error "S3 bucket configuration not set in automq-cluster.yaml"
+        echo ""
+        echo "  Please configure your S3 buckets:"
+        echo ""
+        echo "  1. Create S3 buckets:"
+        echo "     export AWS_REGION=us-east-1"
+        echo "     export BUCKET_SUFFIX=\$(date +%s)"
+        echo "     export DATA_BUCKET=\"automq-data-\${BUCKET_SUFFIX}\""
+        echo "     export OPS_BUCKET=\"automq-ops-\${BUCKET_SUFFIX}\""
+        echo "     aws s3 mb s3://\${DATA_BUCKET} --region \${AWS_REGION}"
+        echo "     aws s3 mb s3://\${OPS_BUCKET} --region \${AWS_REGION}"
+        echo ""
+        echo "  2. Update automq-cluster.yaml:"
+        echo "     sed -i.bak \\"
+        echo "       -e \"s|\\\${OPS_BUCKET}|\${OPS_BUCKET}|g\" \\"
+        echo "       -e \"s|\\\${DATA_BUCKET}|\${DATA_BUCKET}|g\" \\"
+        echo "       -e \"s|\\\${AWS_REGION}|\${AWS_REGION}|g\" \\"
+        echo "       automq-cluster.yaml"
+        echo ""
+        echo "  3. Re-run this script"
+        echo ""
+        exit 1
+    fi
+    
+    print_info "✓ S3 configuration looks good"
+}
+
+install_automq() {
+    print_step "4/4" "Installing AutoMQ Cluster"
+    
+    print_info "Deploying AutoMQ cluster (this may take a few minutes)..."
+    kubectl apply -f automq-cluster.yaml -n "$NAMESPACE"
+    
+    # Wait for cluster to be ready
+    print_info "Waiting for AutoMQ pods to be ready..."
+    
+    MAX_RETRIES=60
+    RETRY_COUNT=0
+    
+    while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+        READY_PODS=$(kubectl get pods -n "$NAMESPACE" -l strimzi.io/cluster=my-cluster -o jsonpath='{range .items[*]}{.status.containerStatuses[0].ready}{"\n"}{end}' 2>/dev/null | grep -c "true" || echo "0")
+        TOTAL_PODS=$(kubectl get pods -n "$NAMESPACE" -l strimzi.io/cluster=my-cluster --no-headers 2>/dev/null | wc -l | tr -d ' ')
+        
+        if [ "$READY_PODS" -ge 3 ] && [ "$READY_PODS" -eq "$TOTAL_PODS" ]; then
+            echo ""
+            print_info "✓ AutoMQ cluster is ready ($READY_PODS pods running)"
+            break
+        fi
+        
+        RETRY_COUNT=$((RETRY_COUNT + 1))
+        printf "\r  Waiting for pods... (%d/%d) - %d/%d pods ready" "$RETRY_COUNT" "$MAX_RETRIES" "$READY_PODS" "$TOTAL_PODS"
+        sleep 5
+    done
+    
+    echo ""
+    
+    if [ "$READY_PODS" -lt 3 ]; then
+        print_warn "Not all pods are ready yet. Check status with: kubectl get pods -n $NAMESPACE"
+        print_warn "Check logs with: kubectl logs -l strimzi.io/cluster=my-cluster -n $NAMESPACE"
+    fi
+}
+
+print_summary() {
+    printf "\n${BLUE}╔══════════════════════════════════════════════════════════════╗${NC}\n"
+    printf "${BLUE}║${NC}                  ${GREEN}Installation Complete!${NC}                      ${BLUE}║${NC}\n"
+    printf "${BLUE}╚══════════════════════════════════════════════════════════════╝${NC}\n\n"
+    
+    echo "  Namespace: $NAMESPACE"
+    echo "  Bootstrap Server: my-cluster-kafka-bootstrap.$NAMESPACE.svc.cluster.local:9092"
+    echo ""
+    echo "  Next Steps:"
+    echo "    ./verify.sh  - Test the cluster"
+    echo "    ./cleanup.sh - Remove the cluster"
+    echo ""
+    echo "  Quick Test:"
+    echo "    kubectl exec -it -n $NAMESPACE my-cluster-controller-0 -- \\"
+    echo "      /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list"
+    echo ""
+}
+
+show_help() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --check    Run pre-flight checks only (do not install)"
+    echo "  --help     Show this help message"
+    echo ""
+    echo "Environment Variables:"
+    echo "  NAMESPACE       Kubernetes namespace (default: automq)"
+    echo "  STRIMZI_VERSION Strimzi version (default: 0.47.0)"
+    echo ""
+    echo "Prerequisites:"
+    echo "  - AWS EKS cluster with r6i.large or larger nodes"
+    echo "  - kubectl and helm installed"
+    echo "  - S3 buckets created and configured in automq-cluster.yaml"
+    echo ""
+    echo "For EKS cluster setup, see:"
+    echo "  byoc-examples/setup/kubernetes/aws/terraform/README.md"
+}
+
+main() {
+    # Parse arguments
+    case "${1:-}" in
+        --check)
+            print_header
+            check_prerequisites
+            echo ""
+            print_info "Pre-flight check completed successfully!"
+            print_info "Run './install.sh' to proceed with installation."
+            exit 0
+            ;;
+        --help|-h)
+            show_help
+            exit 0
+            ;;
+    esac
+
+    print_header
+    check_prerequisites
+    install_strimzi
+    check_s3_config
+    install_automq
+    print_summary
+}
+
+main "$@"

--- a/software-examples/strimzi/strimzi-values.yaml
+++ b/software-examples/strimzi/strimzi-values.yaml
@@ -1,0 +1,9 @@
+env:
+  - name: STRIMZI_FEATURE_GATES
+    value: +KafkaNodePools,+UseKRaft
+extraEnvs:
+  - name: STRIMZI_KAFKA_IMAGES
+    value: |
+      3.9.0=automqinc/automq:1.6.0-strimzi
+      3.9.1=quay.io/strimzi/kafka:0.47.0-kafka-3.9.1
+      4.0.0=quay.io/strimzi/kafka:0.47.0-kafka-4.0.0

--- a/software-examples/strimzi/verify.sh
+++ b/software-examples/strimzi/verify.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -e
+NAMESPACE="${NAMESPACE:-automq}"
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+print_info() { printf "${GREEN}[INFO]${NC} %s\n" "$1"; }
+print_error() { printf "${RED}[ERROR]${NC} %s\n" "$1"; }
+
+echo ""
+echo "=============================================="
+echo " AutoMQ Strimzi Installation Verification"
+echo "=============================================="
+echo ""
+
+print_info "Checking Strimzi Operator..."
+OPERATOR_PODS=$(kubectl get pods -n "$NAMESPACE" -l name=strimzi-cluster-operator --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l | tr -d ' ')
+[ "$OPERATOR_PODS" -ge 1 ] && print_info "✓ Strimzi Operator is running" || { print_error "Strimzi Operator is not running"; exit 1; }
+
+print_info "Checking AutoMQ pods..."
+echo ""
+kubectl get pods -n "$NAMESPACE" -l strimzi.io/cluster=my-cluster
+echo ""
+
+CONTROLLER_PODS=$(kubectl get pods -n "$NAMESPACE" -l strimzi.io/pool-name=controller --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l | tr -d ' ')
+[ "$CONTROLLER_PODS" -ge 3 ] && print_info "✓ All 3 controller pods are running" || print_error "Only $CONTROLLER_PODS/3 controller pods running"
+
+CONTROLLER_POD=$(kubectl get pods -n "$NAMESPACE" -l strimzi.io/pool-name=controller -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+[ -z "$CONTROLLER_POD" ] && { print_error "No controller pod found"; exit 1; }
+
+print_info "Creating test topic..."
+kubectl exec -n "$NAMESPACE" "$CONTROLLER_POD" -- /opt/kafka/bin/kafka-topics.sh \
+    --bootstrap-server localhost:9092 --create --topic test-topic \
+    --partitions 3 --replication-factor 1 --if-not-exists 2>/dev/null || true
+print_info "✓ Test topic created"
+
+print_info "Listing topics..."
+echo ""
+kubectl exec -n "$NAMESPACE" "$CONTROLLER_POD" -- /opt/kafka/bin/kafka-topics.sh \
+    --bootstrap-server localhost:9092 --list 2>/dev/null
+
+echo ""
+echo "=============================================="
+echo " Verification Complete!"
+echo "=============================================="
+echo ""
+print_info "AutoMQ cluster is healthy and ready to use."
+echo ""
+echo "Quick Commands:"
+echo ""
+echo "  # Produce messages"
+echo "  kubectl exec -it -n $NAMESPACE $CONTROLLER_POD -- /opt/kafka/bin/kafka-console-producer.sh \\"
+echo "    --bootstrap-server localhost:9092 --topic test-topic"
+echo ""
+echo "  # Consume messages"
+echo "  kubectl exec -it -n $NAMESPACE $CONTROLLER_POD -- /opt/kafka/bin/kafka-console-consumer.sh \\"
+echo "    --bootstrap-server localhost:9092 --topic test-topic --from-beginning"
+echo ""


### PR DESCRIPTION
## Summary

Add one-click installation setup for deploying AutoMQ using Strimzi Operator on Kubernetes with AWS S3 storage.

## Changes

### New Files
- `software-examples/strimzi/` - Complete Strimzi deployment setup
  - `install.sh` - Installation script with pre-flight checks
  - `cleanup.sh` - Cleanup script with `--force` flag for non-interactive mode
  - `verify.sh` - Verification script for testing cluster health
  - `automq-cluster.yaml` - AutoMQ cluster configuration with S3 placeholders
  - `strimzi-values.yaml` - Strimzi operator Helm values
  - `README.md` - Comprehensive deployment guide

- `byoc-examples/setup/kubernetes/aws/terraform/terraform.tfvars.example` - Example terraform variables

## Features

- **Pre-flight checks**: Validates node instance types, memory, and cluster connectivity
- **Node affinity**: Restricts scheduling to supported instance types (r6i.large, r6i.xlarge, r6i.2xlarge, r6in.large, r6in.xlarge, r6in.2xlarge)
- **Pod anti-affinity**: Ensures each pod runs on a separate node for HA
- **S3 integration**: Uses AWS S3 for data and ops storage
- **Memory configuration**: 12Gi request / 16Gi limit, JVM 6g heap + 6g direct memory

## Testing

- Deployed and tested on AWS EKS with 3 r6i.large nodes
- Verified topic creation, produce/consume operations
- Tested cleanup script with PVC deletion
