### PR TITLE
Add OSS TableBucket table topic example

### DIFF
--- a/opensource-examples/table-topic/README.md
+++ b/opensource-examples/table-topic/README.md
@@ -7,4 +7,4 @@ This directory contains examples for AutoMQ Table Topic, which writes Kafka topi
 | [playground](playground/) | A full local Table Topic playground with MinIO, Iceberg REST Catalog, Schema Registry, Trino, and multiple ingestion scenarios. |
 | [iceberg-spark-streaming](iceberg-spark-streaming/) | A streaming pipeline where AutoMQ writes a source Iceberg table and Spark Structured Streaming transforms it into another Iceberg table. |
 | [hive-metastore-integration](hive-metastore-integration/) | A Table Topic example using Hive Metastore as the Iceberg catalog. |
-| [oss-tablebucket-integration](oss-tablebucket-integration/) | A Table Topic example using Aliyun OSS Tables with both REST Catalog and TableBucket Catalog modes. |
+| [oss-tablebucket-integration](oss-tablebucket-integration/) | A Table Topic example using Aliyun OSS Tables with both REST Catalog and OSS S3 Tables Catalog modes. |

--- a/opensource-examples/table-topic/README.md
+++ b/opensource-examples/table-topic/README.md
@@ -1,0 +1,10 @@
+# AutoMQ Table Topic Examples
+
+This directory contains examples for AutoMQ Table Topic, which writes Kafka topic data into Apache Iceberg tables.
+
+| Example | Description |
+| --- | --- |
+| [playground](playground/) | A full local Table Topic playground with MinIO, Iceberg REST Catalog, Schema Registry, Trino, and multiple ingestion scenarios. |
+| [iceberg-spark-streaming](iceberg-spark-streaming/) | A streaming pipeline where AutoMQ writes a source Iceberg table and Spark Structured Streaming transforms it into another Iceberg table. |
+| [hive-metastore-integration](hive-metastore-integration/) | A Table Topic example using Hive Metastore as the Iceberg catalog. |
+| [oss-tablebucket-integration](oss-tablebucket-integration/) | A Table Topic example using Aliyun OSS Tables with both REST Catalog and TableBucket Catalog modes. |

--- a/opensource-examples/table-topic/hive-metastore-integration/docker-compose.yaml
+++ b/opensource-examples/table-topic/hive-metastore-integration/docker-compose.yaml
@@ -95,7 +95,7 @@ services:
 
   automq:
     container_name: "automq"
-    image: automqinc/automq:1.6.0
+    image: automqinc/automq:1.7.0
     stop_grace_period: 1m
     networks:
       - iceberg-hms-net

--- a/opensource-examples/table-topic/iceberg-spark-streaming/docker-compose.yml
+++ b/opensource-examples/table-topic/iceberg-spark-streaming/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       "
   automq:
     container_name: "automq"
-    image: automqinc/automq:1.5
+    image: automqinc/automq:1.7.0
     stop_grace_period: 1m
     networks:
       iceberg_net:

--- a/opensource-examples/table-topic/oss-tablebucket-integration/.env.example
+++ b/opensource-examples/table-topic/oss-tablebucket-integration/.env.example
@@ -1,0 +1,12 @@
+# AWS SDK-compatible credentials used by Aliyun OSS Tables APIs.
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=cn-hangzhou
+AWS_DEFAULT_REGION=cn-hangzhou
+
+# Aliyun OSS Tables / TableBucket resources.
+OSS_TABLE_BUCKET_ARN=acs:osstables:cn-hangzhou:<account-id>:bucket/<table-bucket>
+OSS_TABLES_ENDPOINT=https://cn-hangzhou.oss-tables.aliyuncs.com
+OSS_ICEBERG_REST_URI=https://cn-hangzhou.oss-tables.aliyuncs.com/iceberg
+OSS_ENDPOINT=https://oss-cn-hangzhou.aliyuncs.com
+TABLE_TOPIC_NAMESPACE=automq_it

--- a/opensource-examples/table-topic/oss-tablebucket-integration/CATALOG_CONFIG.md
+++ b/opensource-examples/table-topic/oss-tablebucket-integration/CATALOG_CONFIG.md
@@ -1,0 +1,84 @@
+# Catalog Configuration
+
+This document describes the catalog settings used by the `oss-tablebucket-integration` example.
+
+## Environment Variables
+
+The example reads Aliyun settings from `.env`:
+
+```env
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=cn-hangzhou
+AWS_DEFAULT_REGION=cn-hangzhou
+
+OSS_TABLE_BUCKET_ARN=acs:osstables:cn-hangzhou:<account-id>:bucket/<table-bucket>
+OSS_TABLES_ENDPOINT=https://cn-hangzhou.oss-tables.aliyuncs.com
+OSS_ICEBERG_REST_URI=https://cn-hangzhou.oss-tables.aliyuncs.com/iceberg
+OSS_ENDPOINT=https://oss-cn-hangzhou.aliyuncs.com
+TABLE_TOPIC_NAMESPACE=automq_it
+```
+
+`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, and `AWS_DEFAULT_REGION` use AWS SDK-compatible names because the Iceberg catalog and file I/O libraries use AWS SDK credential providers.
+
+## AutoMQ with OSS Tables REST Catalog
+
+`docker-compose.automq-rest.yml` configures AutoMQ Table Topic to use the OSS Tables REST Catalog:
+
+```properties
+automq.table.topic.catalog.type=rest
+automq.table.topic.catalog.uri=${OSS_ICEBERG_REST_URI}
+automq.table.topic.catalog.warehouse=${OSS_TABLE_BUCKET_ARN}
+automq.table.topic.catalog.rest.sigv4-enabled=true
+automq.table.topic.catalog.rest.signing-region=${AWS_REGION}
+automq.table.topic.catalog.rest.signing-name=osstables
+automq.table.topic.catalog.client.region=${AWS_REGION}
+automq.table.topic.catalog.client.credentials-provider=software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+automq.table.topic.catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO
+automq.table.topic.catalog.s3.endpoint=${OSS_ENDPOINT}
+automq.table.topic.catalog.s3.path-style-access=false
+automq.table.topic.namespace=${TABLE_TOPIC_NAMESPACE}
+automq.table.topic.schema.registry.url=http://schema-registry:8081
+```
+
+`warehouse` is the OSS TableBucket ARN.
+
+## AutoMQ with OSS TableBucket Catalog
+
+`docker-compose.automq-tablebucket.yml` configures AutoMQ Table Topic to use the OSS TableBucket Catalog:
+
+```properties
+automq.table.topic.catalog.type=tablebucket
+automq.table.topic.catalog.warehouse=${OSS_TABLE_BUCKET_ARN}
+automq.table.topic.catalog.s3tables.endpoint=${OSS_TABLES_ENDPOINT}
+automq.table.topic.catalog.client.region=${AWS_REGION}
+automq.table.topic.catalog.client.credentials-provider=software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+automq.table.topic.catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO
+automq.table.topic.catalog.s3.endpoint=${OSS_ENDPOINT}
+automq.table.topic.catalog.s3.path-style-access=false
+automq.table.topic.namespace=${TABLE_TOPIC_NAMESPACE}
+automq.table.topic.schema.registry.url=http://schema-registry:8081
+```
+
+The `s3.endpoint` and `s3.path-style-access=false` settings are required by `S3FileIO` when it writes Iceberg metadata and data files to Aliyun OSS.
+
+## Trino Catalog
+
+The Trino container generates `/etc/trino/catalog/iceberg.properties` from `.env`:
+
+```properties
+connector.name=iceberg
+iceberg.catalog.type=rest
+iceberg.rest-catalog.uri=${OSS_ICEBERG_REST_URI}
+iceberg.rest-catalog.warehouse=${OSS_TABLE_BUCKET_ARN}
+iceberg.rest-catalog.security=SIGV4
+iceberg.rest-catalog.signing-name=osstables
+iceberg.register-table-procedure.enabled=true
+fs.native-s3.enabled=true
+s3.endpoint=${OSS_ENDPOINT}
+s3.path-style-access=false
+s3.aws-access-key=${AWS_ACCESS_KEY_ID}
+s3.aws-secret-key=${AWS_SECRET_ACCESS_KEY}
+s3.region=${AWS_REGION}
+iceberg.file-format=PARQUET
+```

--- a/opensource-examples/table-topic/oss-tablebucket-integration/CATALOG_CONFIG.md
+++ b/opensource-examples/table-topic/oss-tablebucket-integration/CATALOG_CONFIG.md
@@ -41,11 +41,11 @@ automq.table.topic.namespace=${TABLE_TOPIC_NAMESPACE}
 automq.table.topic.schema.registry.url=http://schema-registry:8081
 ```
 
-`warehouse` is the OSS TableBucket ARN.
+`warehouse` is the OSS Tables Table Bucket ARN.
 
-## AutoMQ with OSS TableBucket Catalog
+## AutoMQ with OSS S3 Tables Catalog
 
-`docker-compose.automq-tablebucket.yml` configures AutoMQ Table Topic to use the OSS TableBucket Catalog:
+`docker-compose.automq-tablebucket.yml` configures AutoMQ Table Topic to use the OSS S3 Tables Catalog-compatible path:
 
 ```properties
 automq.table.topic.catalog.type=tablebucket
@@ -59,6 +59,8 @@ automq.table.topic.catalog.s3.path-style-access=false
 automq.table.topic.namespace=${TABLE_TOPIC_NAMESPACE}
 automq.table.topic.schema.registry.url=http://schema-registry:8081
 ```
+
+This mode maps to the S3 Tables Catalog implementation path used by `awslabs/s3-tables-catalog`, exposed in AutoMQ as `automq.table.topic.catalog.type=tablebucket`.
 
 The `s3.endpoint` and `s3.path-style-access=false` settings are required by `S3FileIO` when it writes Iceberg metadata and data files to Aliyun OSS.
 

--- a/opensource-examples/table-topic/oss-tablebucket-integration/CATALOG_CONFIG.md
+++ b/opensource-examples/table-topic/oss-tablebucket-integration/CATALOG_CONFIG.md
@@ -64,23 +64,24 @@ This mode maps to the S3 Tables Catalog implementation path used by `awslabs/s3-
 
 The `s3.endpoint` and `s3.path-style-access=false` settings are required by `S3FileIO` when it writes Iceberg metadata and data files to Aliyun OSS.
 
-## Trino Catalog
+## Spark Catalog
 
-The Trino container generates `/etc/trino/catalog/iceberg.properties` from `.env`:
+The Spark SQL commands configure an Iceberg REST catalog named `oss_tables`:
 
 ```properties
-connector.name=iceberg
-iceberg.catalog.type=rest
-iceberg.rest-catalog.uri=${OSS_ICEBERG_REST_URI}
-iceberg.rest-catalog.warehouse=${OSS_TABLE_BUCKET_ARN}
-iceberg.rest-catalog.security=SIGV4
-iceberg.rest-catalog.signing-name=osstables
-iceberg.register-table-procedure.enabled=true
-fs.native-s3.enabled=true
-s3.endpoint=${OSS_ENDPOINT}
-s3.path-style-access=false
-s3.aws-access-key=${AWS_ACCESS_KEY_ID}
-s3.aws-secret-key=${AWS_SECRET_ACCESS_KEY}
-s3.region=${AWS_REGION}
-iceberg.file-format=PARQUET
+spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
+spark.sql.catalog.oss_tables=org.apache.iceberg.spark.SparkCatalog
+spark.sql.catalog.oss_tables.type=rest
+spark.sql.catalog.oss_tables.uri=${OSS_ICEBERG_REST_URI}
+spark.sql.catalog.oss_tables.warehouse=${OSS_TABLE_BUCKET_ARN}
+spark.sql.catalog.oss_tables.rest.sigv4-enabled=true
+spark.sql.catalog.oss_tables.rest.signing-name=osstables
+spark.sql.catalog.oss_tables.rest.signing-region=${AWS_REGION}
+spark.sql.catalog.oss_tables.client.region=${AWS_REGION}
+spark.sql.catalog.oss_tables.client.credentials-provider=software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+spark.sql.catalog.oss_tables.io-impl=org.apache.iceberg.aws.s3.S3FileIO
+spark.sql.catalog.oss_tables.s3.endpoint=${OSS_ENDPOINT}
+spark.sql.catalog.oss_tables.s3.path-style-access=false
 ```
+
+Spark uses Iceberg's `S3FileIO` for data reads, so it can query tables written by both AutoMQ catalog modes through the OSS Tables REST Catalog.

--- a/opensource-examples/table-topic/oss-tablebucket-integration/README.md
+++ b/opensource-examples/table-topic/oss-tablebucket-integration/README.md
@@ -7,7 +7,7 @@ It covers two AutoMQ catalog modes:
 - OSS Tables REST Catalog
 - OSS S3 Tables Catalog
 
-AutoMQ uses local MinIO for its own stream storage in this example. Table Topic writes Iceberg metadata and data to Aliyun OSS Tables / OSS. Trino is included for querying the resulting Iceberg tables through the OSS Tables REST Catalog.
+AutoMQ uses local MinIO for its own stream storage in this example. Table Topic writes Iceberg metadata and data to Aliyun OSS Tables / OSS. Spark SQL is included for querying the resulting Iceberg tables through the OSS Tables REST Catalog.
 
 For the catalog settings used by each mode, see [CATALOG_CONFIG.md](CATALOG_CONFIG.md).
 
@@ -57,10 +57,10 @@ just test-rest
 
 By default this writes to the `orders_rest` table in `TABLE_TOPIC_NAMESPACE`.
 
-Query the table with Trino:
+Query the table with Spark SQL:
 
 ```bash
-just trino-sql-rest "SELECT * FROM automq_it.orders_rest LIMIT 10"
+just query-rest
 ```
 
 ## Run with OSS S3 Tables Catalog
@@ -81,10 +81,10 @@ By default this writes to the `orders_tablebucket` table in `TABLE_TOPIC_NAMESPA
 
 The `tablebucket` command and compose names match AutoMQ's `automq.table.topic.catalog.type=tablebucket` configuration value. The catalog path itself is the S3 Tables Catalog-compatible path.
 
-Query the table with Trino:
+Query the table with Spark SQL:
 
 ```bash
-just trino-sql-tablebucket "SELECT * FROM automq_it.orders_tablebucket LIMIT 10"
+just query-tablebucket
 ```
 
 ## Custom Topic Names
@@ -103,6 +103,8 @@ just status-rest
 just status-tablebucket
 just logs-rest automq
 just logs-tablebucket automq
+just spark-sql-rest "SHOW TABLES IN oss_tables.automq_it"
+just spark-sql-tablebucket "SHOW TABLES IN oss_tables.automq_it"
 just down
 ```
 

--- a/opensource-examples/table-topic/oss-tablebucket-integration/README.md
+++ b/opensource-examples/table-topic/oss-tablebucket-integration/README.md
@@ -1,0 +1,115 @@
+# AutoMQ Table Topic with Aliyun OSS TableBucket
+
+This example shows how to write Avro messages from AutoMQ Table Topic into Aliyun OSS Tables.
+
+It covers two AutoMQ catalog modes:
+
+- OSS Tables REST Catalog
+- OSS TableBucket Catalog
+
+AutoMQ uses local MinIO for its own stream storage in this example. Table Topic writes Iceberg metadata and data to Aliyun OSS Tables / OSS. Trino is included for querying the resulting Iceberg tables through the OSS Tables REST Catalog.
+
+For the catalog settings used by each mode, see [CATALOG_CONFIG.md](CATALOG_CONFIG.md).
+
+## Prerequisites
+
+- Docker
+- `just`
+- An Aliyun OSS TableBucket
+- AK/SK with permission to access OSS Tables and OSS
+- Public network access to the configured Aliyun endpoints
+
+## Configure
+
+Create a local `.env` file:
+
+```bash
+cp .env.example .env
+```
+
+Fill in the Aliyun credentials and resource settings:
+
+```env
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=cn-hangzhou
+AWS_DEFAULT_REGION=cn-hangzhou
+OSS_TABLE_BUCKET_ARN=acs:osstables:cn-hangzhou:<account-id>:bucket/<table-bucket>
+OSS_TABLES_ENDPOINT=https://cn-hangzhou.oss-tables.aliyuncs.com
+OSS_ICEBERG_REST_URI=https://cn-hangzhou.oss-tables.aliyuncs.com/iceberg
+OSS_ENDPOINT=https://oss-cn-hangzhou.aliyuncs.com
+TABLE_TOPIC_NAMESPACE=automq_it
+```
+
+## Run with OSS Tables REST Catalog
+
+Start the environment:
+
+```bash
+just up-rest
+```
+
+Create the Table Topic, produce Avro records, and wait for a successful Table Topic commit:
+
+```bash
+just test-rest
+```
+
+By default this writes to the `orders_rest` table in `TABLE_TOPIC_NAMESPACE`.
+
+Query the table with Trino:
+
+```bash
+just trino-sql-rest "SELECT * FROM automq_it.orders_rest LIMIT 10"
+```
+
+## Run with OSS TableBucket Catalog
+
+Start the environment:
+
+```bash
+just up-tablebucket
+```
+
+Create the Table Topic, produce Avro records, and wait for a successful Table Topic commit:
+
+```bash
+just test-tablebucket
+```
+
+By default this writes to the `orders_tablebucket` table in `TABLE_TOPIC_NAMESPACE`.
+
+Query the table with Trino:
+
+```bash
+just trino-sql-tablebucket "SELECT * FROM automq_it.orders_tablebucket LIMIT 10"
+```
+
+## Custom Topic Names
+
+The default table names make the two catalog modes easy to compare. You can override them:
+
+```bash
+just test-rest my_rest_table 20
+just test-tablebucket my_tablebucket_table 20
+```
+
+## Useful Commands
+
+```bash
+just status-rest
+just status-tablebucket
+just logs-rest automq
+just logs-tablebucket automq
+just down
+```
+
+## Cleanup
+
+Stop local containers and remove local volumes:
+
+```bash
+just down
+```
+
+This does not delete remote tables or data in Aliyun OSS Tables / OSS. Delete remote test tables from your Aliyun environment when they are no longer needed.

--- a/opensource-examples/table-topic/oss-tablebucket-integration/README.md
+++ b/opensource-examples/table-topic/oss-tablebucket-integration/README.md
@@ -1,11 +1,11 @@
-# AutoMQ Table Topic with Aliyun OSS TableBucket
+# AutoMQ Table Topic with Aliyun OSS Tables
 
 This example shows how to write Avro messages from AutoMQ Table Topic into Aliyun OSS Tables.
 
 It covers two AutoMQ catalog modes:
 
 - OSS Tables REST Catalog
-- OSS TableBucket Catalog
+- OSS S3 Tables Catalog
 
 AutoMQ uses local MinIO for its own stream storage in this example. Table Topic writes Iceberg metadata and data to Aliyun OSS Tables / OSS. Trino is included for querying the resulting Iceberg tables through the OSS Tables REST Catalog.
 
@@ -15,7 +15,7 @@ For the catalog settings used by each mode, see [CATALOG_CONFIG.md](CATALOG_CONF
 
 - Docker
 - `just`
-- An Aliyun OSS TableBucket
+- An Aliyun OSS Tables Table Bucket
 - AK/SK with permission to access OSS Tables and OSS
 - Public network access to the configured Aliyun endpoints
 
@@ -63,7 +63,7 @@ Query the table with Trino:
 just trino-sql-rest "SELECT * FROM automq_it.orders_rest LIMIT 10"
 ```
 
-## Run with OSS TableBucket Catalog
+## Run with OSS S3 Tables Catalog
 
 Start the environment:
 
@@ -78,6 +78,8 @@ just test-tablebucket
 ```
 
 By default this writes to the `orders_tablebucket` table in `TABLE_TOPIC_NAMESPACE`.
+
+The `tablebucket` command and compose names match AutoMQ's `automq.table.topic.catalog.type=tablebucket` configuration value. The catalog path itself is the S3 Tables Catalog-compatible path.
 
 Query the table with Trino:
 

--- a/opensource-examples/table-topic/oss-tablebucket-integration/docker-compose.automq-rest.yml
+++ b/opensource-examples/table-topic/oss-tablebucket-integration/docker-compose.automq-rest.yml
@@ -1,0 +1,67 @@
+services:
+  automq:
+    image: automqinc/automq:1.7.0
+    container_name: oss-tablebucket-automq
+    hostname: automq
+    stop_grace_period: 1m
+    environment:
+      - KAFKA_S3_ACCESS_KEY=admin
+      - KAFKA_S3_SECRET_KEY=password
+      - KAFKA_HEAP_OPTS=-Xms1g -Xmx4g -XX:MetaspaceSize=96m -XX:MaxDirectMemorySize=1G
+      - CLUSTER_ID=3D4fXN-yS1-vsQ8aJ_q4Mg
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      - AWS_REGION=${AWS_REGION:-}
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-}
+      - OSS_TABLE_BUCKET_ARN=${OSS_TABLE_BUCKET_ARN:-}
+      - OSS_ICEBERG_REST_URI=${OSS_ICEBERG_REST_URI:-}
+      - OSS_ENDPOINT=${OSS_ENDPOINT:-}
+      - TABLE_TOPIC_NAMESPACE=${TABLE_TOPIC_NAMESPACE:-automq_it}
+    ports:
+      - "39092:9092"
+      - "39093:9093"
+      - "39090:9090"
+    command:
+      - bash
+      - -c
+      - |
+        /opt/automq/kafka/bin/kafka-server-start.sh \
+        /opt/automq/kafka/config/kraft/server.properties \
+        --override cluster.id=$${CLUSTER_ID} \
+        --override node.id=0 \
+        --override controller.quorum.voters=0@automq:9093 \
+        --override controller.quorum.bootstrap.servers=automq:9093 \
+        --override listeners=PLAINTEXT://:9092,CONTROLLER://:9093 \
+        --override advertised.listeners=PLAINTEXT://automq:9092 \
+        --override s3.data.buckets='0@s3://automq-data?region=us-east-1&endpoint=http://minio:9000&pathStyle=true' \
+        --override s3.ops.buckets='1@s3://automq-ops?region=us-east-1&endpoint=http://minio:9000&pathStyle=true' \
+        --override s3.wal.path='0@s3://automq-data?region=us-east-1&endpoint=http://minio:9000&pathStyle=true' \
+        --override automq.table.topic.catalog.type=rest \
+        --override automq.table.topic.catalog.uri=$${OSS_ICEBERG_REST_URI:-} \
+        --override automq.table.topic.catalog.warehouse=$${OSS_TABLE_BUCKET_ARN:-} \
+        --override automq.table.topic.catalog.rest.sigv4-enabled=true \
+        --override automq.table.topic.catalog.rest.signing-region=$${AWS_REGION:-} \
+        --override automq.table.topic.catalog.rest.signing-name=osstables \
+        --override automq.table.topic.catalog.client.region=$${AWS_REGION:-} \
+        --override automq.table.topic.catalog.client.credentials-provider=software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider \
+        --override automq.table.topic.catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
+        --override automq.table.topic.catalog.s3.endpoint=$${OSS_ENDPOINT:-} \
+        --override automq.table.topic.catalog.s3.path-style-access=false \
+        --override automq.table.topic.namespace=$${TABLE_TOPIC_NAMESPACE:-automq_it} \
+        --override automq.table.topic.schema.registry.url=http://schema-registry:8081 \
+        --override s3.telemetry.metrics.exporter.type=prometheus \
+        --override s3.metrics.exporter.prom.host=0.0.0.0 \
+        --override s3.metrics.exporter.prom.port=9090
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/automq/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 >/dev/null 2>&1"]
+      interval: 20s
+      timeout: 20s
+      retries: 8
+      start_period: 30s
+    depends_on:
+      minio:
+        condition: service_healthy
+      mc:
+        condition: service_started
+    networks:
+      oss_tablebucket_net:

--- a/opensource-examples/table-topic/oss-tablebucket-integration/docker-compose.automq-tablebucket.yml
+++ b/opensource-examples/table-topic/oss-tablebucket-integration/docker-compose.automq-tablebucket.yml
@@ -1,0 +1,64 @@
+services:
+  automq:
+    image: automqinc/automq:1.7.0
+    container_name: oss-tablebucket-automq
+    hostname: automq
+    stop_grace_period: 1m
+    environment:
+      - KAFKA_S3_ACCESS_KEY=admin
+      - KAFKA_S3_SECRET_KEY=password
+      - KAFKA_HEAP_OPTS=-Xms1g -Xmx4g -XX:MetaspaceSize=96m -XX:MaxDirectMemorySize=1G
+      - CLUSTER_ID=3D4fXN-yS1-vsQ8aJ_q4Mg
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      - AWS_REGION=${AWS_REGION:-}
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-}
+      - OSS_TABLE_BUCKET_ARN=${OSS_TABLE_BUCKET_ARN:-}
+      - OSS_TABLES_ENDPOINT=${OSS_TABLES_ENDPOINT:-}
+      - OSS_ENDPOINT=${OSS_ENDPOINT:-}
+      - TABLE_TOPIC_NAMESPACE=${TABLE_TOPIC_NAMESPACE:-automq_it}
+    ports:
+      - "39092:9092"
+      - "39093:9093"
+      - "39090:9090"
+    command:
+      - bash
+      - -c
+      - |
+        /opt/automq/kafka/bin/kafka-server-start.sh \
+        /opt/automq/kafka/config/kraft/server.properties \
+        --override cluster.id=$${CLUSTER_ID} \
+        --override node.id=0 \
+        --override controller.quorum.voters=0@automq:9093 \
+        --override controller.quorum.bootstrap.servers=automq:9093 \
+        --override listeners=PLAINTEXT://:9092,CONTROLLER://:9093 \
+        --override advertised.listeners=PLAINTEXT://automq:9092 \
+        --override s3.data.buckets='0@s3://automq-data?region=us-east-1&endpoint=http://minio:9000&pathStyle=true' \
+        --override s3.ops.buckets='1@s3://automq-ops?region=us-east-1&endpoint=http://minio:9000&pathStyle=true' \
+        --override s3.wal.path='0@s3://automq-data?region=us-east-1&endpoint=http://minio:9000&pathStyle=true' \
+        --override automq.table.topic.catalog.type=tablebucket \
+        --override automq.table.topic.catalog.warehouse=$${OSS_TABLE_BUCKET_ARN:-} \
+        --override automq.table.topic.catalog.s3tables.endpoint=$${OSS_TABLES_ENDPOINT:-} \
+        --override automq.table.topic.catalog.client.region=$${AWS_REGION:-} \
+        --override automq.table.topic.catalog.client.credentials-provider=software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider \
+        --override automq.table.topic.catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
+        --override automq.table.topic.catalog.s3.endpoint=$${OSS_ENDPOINT:-} \
+        --override automq.table.topic.catalog.s3.path-style-access=false \
+        --override automq.table.topic.namespace=$${TABLE_TOPIC_NAMESPACE:-automq_it} \
+        --override automq.table.topic.schema.registry.url=http://schema-registry:8081 \
+        --override s3.telemetry.metrics.exporter.type=prometheus \
+        --override s3.metrics.exporter.prom.host=0.0.0.0 \
+        --override s3.metrics.exporter.prom.port=9090
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/automq/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 >/dev/null 2>&1"]
+      interval: 20s
+      timeout: 20s
+      retries: 8
+      start_period: 30s
+    depends_on:
+      minio:
+        condition: service_healthy
+      mc:
+        condition: service_started
+    networks:
+      oss_tablebucket_net:

--- a/opensource-examples/table-topic/oss-tablebucket-integration/docker-compose.yml
+++ b/opensource-examples/table-topic/oss-tablebucket-integration/docker-compose.yml
@@ -77,40 +77,24 @@ services:
     networks:
       oss_tablebucket_net:
 
-  trino:
-    image: trinodb/trino:481
-    container_name: oss-tablebucket-trino
-    hostname: trino
-    user: root
+  spark-iceberg:
+    image: tabulario/spark-iceberg
+    container_name: oss-tablebucket-spark-iceberg
+    hostname: spark-iceberg
     environment:
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
       AWS_REGION: ${AWS_REGION:-}
+      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION:-}
       OSS_TABLE_BUCKET_ARN: ${OSS_TABLE_BUCKET_ARN:-}
       OSS_ICEBERG_REST_URI: ${OSS_ICEBERG_REST_URI:-}
       OSS_ENDPOINT: ${OSS_ENDPOINT:-}
     ports:
-      - "18090:8080"
-    entrypoint: ["/bin/sh", "-c"]
-    command:
-      - |
-        cat > /etc/trino/catalog/iceberg.properties <<EOF
-        connector.name=iceberg
-        iceberg.catalog.type=rest
-        iceberg.rest-catalog.uri=$${OSS_ICEBERG_REST_URI:-}
-        iceberg.rest-catalog.warehouse=$${OSS_TABLE_BUCKET_ARN:-}
-        iceberg.rest-catalog.security=SIGV4
-        iceberg.rest-catalog.signing-name=osstables
-        iceberg.register-table-procedure.enabled=true
-        fs.native-s3.enabled=true
-        s3.endpoint=$${OSS_ENDPOINT:-}
-        s3.path-style-access=false
-        s3.aws-access-key=$${AWS_ACCESS_KEY_ID:-}
-        s3.aws-secret-key=$${AWS_SECRET_ACCESS_KEY:-}
-        s3.region=$${AWS_REGION:-}
-        iceberg.file-format=PARQUET
-        EOF
-        /usr/lib/trino/bin/run-trino
+      - "18080:8080"
+      - "18888:8888"
+      - "10000:10000"
+      - "10001:10001"
+    entrypoint: ["tail", "-f", "/dev/null"]
     networks:
       oss_tablebucket_net:
 

--- a/opensource-examples/table-topic/oss-tablebucket-integration/docker-compose.yml
+++ b/opensource-examples/table-topic/oss-tablebucket-integration/docker-compose.yml
@@ -1,0 +1,118 @@
+services:
+  minio:
+    image: minio/minio:RELEASE.2025-05-24T17-08-30Z
+    container_name: oss-tablebucket-minio
+    hostname: minio
+    environment:
+      - MINIO_ROOT_USER=admin
+      - MINIO_ROOT_PASSWORD=password
+      - MINIO_DOMAIN=minio
+    ports:
+      - "19000:9000"
+      - "19001:9001"
+    command: ["server", "/data", "--console-address", ":9001"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://minio:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    networks:
+      oss_tablebucket_net:
+
+  mc:
+    image: minio/mc:RELEASE.2025-05-21T01-59-54Z
+    container_name: oss-tablebucket-mc
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      until (/usr/bin/mc alias set minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
+      /usr/bin/mc rm -r --force minio/automq-data;
+      /usr/bin/mc rm -r --force minio/automq-ops;
+      /usr/bin/mc mb minio/automq-data;
+      /usr/bin/mc mb minio/automq-ops;
+      /usr/bin/mc anonymous set public minio/automq-data;
+      /usr/bin/mc anonymous set public minio/automq-ops;
+      tail -f /dev/null
+      "
+    networks:
+      oss_tablebucket_net:
+
+  schema-registry:
+    image: confluentinc/cp-schema-registry:latest
+    container_name: oss-tablebucket-schema-registry
+    hostname: schema-registry
+    ports:
+      - "18081:8081"
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: automq:9092
+      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
+    depends_on:
+      automq:
+        condition: service_healthy
+    restart: on-failure
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8081/subjects || exit 1"]
+      interval: 10s
+      timeout: 30s
+      retries: 30
+    networks:
+      oss_tablebucket_net:
+
+  producer:
+    build:
+      context: producer
+    container_name: oss-tablebucket-producer
+    hostname: producer
+    environment:
+      BOOTSTRAP_SERVERS: automq:9092
+      SCHEMA_REGISTRY_URL: http://schema-registry:8081
+      TABLE_TOPIC_NAMESPACE: ${TABLE_TOPIC_NAMESPACE:-automq_it}
+    depends_on:
+      schema-registry:
+        condition: service_healthy
+    command: ["tail", "-f", "/dev/null"]
+    networks:
+      oss_tablebucket_net:
+
+  trino:
+    image: trinodb/trino:481
+    container_name: oss-tablebucket-trino
+    hostname: trino
+    user: root
+    environment:
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      AWS_REGION: ${AWS_REGION:-}
+      OSS_TABLE_BUCKET_ARN: ${OSS_TABLE_BUCKET_ARN:-}
+      OSS_ICEBERG_REST_URI: ${OSS_ICEBERG_REST_URI:-}
+      OSS_ENDPOINT: ${OSS_ENDPOINT:-}
+    ports:
+      - "18090:8080"
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        cat > /etc/trino/catalog/iceberg.properties <<EOF
+        connector.name=iceberg
+        iceberg.catalog.type=rest
+        iceberg.rest-catalog.uri=$${OSS_ICEBERG_REST_URI:-}
+        iceberg.rest-catalog.warehouse=$${OSS_TABLE_BUCKET_ARN:-}
+        iceberg.rest-catalog.security=SIGV4
+        iceberg.rest-catalog.signing-name=osstables
+        iceberg.register-table-procedure.enabled=true
+        fs.native-s3.enabled=true
+        s3.endpoint=$${OSS_ENDPOINT:-}
+        s3.path-style-access=false
+        s3.aws-access-key=$${AWS_ACCESS_KEY_ID:-}
+        s3.aws-secret-key=$${AWS_SECRET_ACCESS_KEY:-}
+        s3.region=$${AWS_REGION:-}
+        iceberg.file-format=PARQUET
+        EOF
+        /usr/lib/trino/bin/run-trino
+    networks:
+      oss_tablebucket_net:
+
+networks:
+  oss_tablebucket_net:

--- a/opensource-examples/table-topic/oss-tablebucket-integration/justfile
+++ b/opensource-examples/table-topic/oss-tablebucket-integration/justfile
@@ -4,11 +4,11 @@ COMPOSE_TABLEBUCKET := "docker compose -f docker-compose.yml -f docker-compose.a
 default: help
 
 help:
-    @echo "AutoMQ Table Topic with Aliyun OSS TableBucket"
+    @echo "AutoMQ Table Topic with Aliyun OSS Tables"
     @echo ""
     @echo "Environment:"
     @echo "  up-rest                 Start AutoMQ with OSS Tables REST Catalog"
-    @echo "  up-tablebucket          Start AutoMQ with OSS TableBucket Catalog"
+    @echo "  up-tablebucket          Start AutoMQ with OSS S3 Tables Catalog"
     @echo "  down                    Stop local containers and remove local volumes"
     @echo "  status-rest             Show REST-mode container status"
     @echo "  status-tablebucket      Show TableBucket-mode container status"

--- a/opensource-examples/table-topic/oss-tablebucket-integration/justfile
+++ b/opensource-examples/table-topic/oss-tablebucket-integration/justfile
@@ -1,0 +1,143 @@
+COMPOSE_REST := "docker compose -f docker-compose.yml -f docker-compose.automq-rest.yml"
+COMPOSE_TABLEBUCKET := "docker compose -f docker-compose.yml -f docker-compose.automq-tablebucket.yml"
+
+default: help
+
+help:
+    @echo "AutoMQ Table Topic with Aliyun OSS TableBucket"
+    @echo ""
+    @echo "Environment:"
+    @echo "  up-rest                 Start AutoMQ with OSS Tables REST Catalog"
+    @echo "  up-tablebucket          Start AutoMQ with OSS TableBucket Catalog"
+    @echo "  down                    Stop local containers and remove local volumes"
+    @echo "  status-rest             Show REST-mode container status"
+    @echo "  status-tablebucket      Show TableBucket-mode container status"
+    @echo "  logs-rest [service]     Tail REST-mode logs"
+    @echo "  logs-tablebucket [svc]  Tail TableBucket-mode logs"
+    @echo ""
+    @echo "Test:"
+    @echo "  test-rest [topic] [count]"
+    @echo "  test-tablebucket [topic] [count]"
+    @echo ""
+    @echo "Manual steps:"
+    @echo "  create-topic-rest [topic]"
+    @echo "  create-topic-tablebucket [topic]"
+    @echo "  produce-rest [topic] [count]"
+    @echo "  produce-tablebucket [topic] [count]"
+    @echo "  check-commit-rest [topic]"
+    @echo "  check-commit-tablebucket [topic]"
+    @echo "  trino-sql-rest <SQL>"
+    @echo "  trino-sql-tablebucket <SQL>"
+
+up-rest:
+    @test -f .env || (echo "Missing .env. Copy .env.example to .env and fill in your Aliyun settings." && exit 1)
+    {{COMPOSE_REST}} up --build -d
+    @just _wait-rest
+
+up-tablebucket:
+    @test -f .env || (echo "Missing .env. Copy .env.example to .env and fill in your Aliyun settings." && exit 1)
+    {{COMPOSE_TABLEBUCKET}} up --build -d
+    @just _wait-tablebucket
+
+down:
+    {{COMPOSE_REST}} down -v --remove-orphans || true
+    {{COMPOSE_TABLEBUCKET}} down -v --remove-orphans || true
+
+status-rest:
+    {{COMPOSE_REST}} ps
+
+status-tablebucket:
+    {{COMPOSE_TABLEBUCKET}} ps
+
+logs-rest service="":
+    #!/usr/bin/env bash
+    if [ -z "{{service}}" ]; then
+      {{COMPOSE_REST}} logs -f
+    else
+      {{COMPOSE_REST}} logs -f "{{service}}"
+    fi
+
+logs-tablebucket service="":
+    #!/usr/bin/env bash
+    if [ -z "{{service}}" ]; then
+      {{COMPOSE_TABLEBUCKET}} logs -f
+    else
+      {{COMPOSE_TABLEBUCKET}} logs -f "{{service}}"
+    fi
+
+create-topic-rest topic="orders_rest":
+    {{COMPOSE_REST}} exec producer python /app/producer.py create-topic --topic "{{topic}}"
+
+create-topic-tablebucket topic="orders_tablebucket":
+    {{COMPOSE_TABLEBUCKET}} exec producer python /app/producer.py create-topic --topic "{{topic}}"
+
+produce-rest topic="orders_rest" count="10":
+    {{COMPOSE_REST}} exec producer python /app/producer.py produce-avro --topic "{{topic}}" --count "{{count}}"
+
+produce-tablebucket topic="orders_tablebucket" count="10":
+    {{COMPOSE_TABLEBUCKET}} exec producer python /app/producer.py produce-avro --topic "{{topic}}" --count "{{count}}"
+
+check-commit-rest topic="orders_rest":
+    @just _check-commit "{{COMPOSE_REST}}" "{{topic}}"
+
+check-commit-tablebucket topic="orders_tablebucket":
+    @just _check-commit "{{COMPOSE_TABLEBUCKET}}" "{{topic}}"
+
+test-rest topic="orders_rest" count="10":
+    @just up-rest
+    @just create-topic-rest "{{topic}}"
+    @just produce-rest "{{topic}}" "{{count}}"
+    @just check-commit-rest "{{topic}}"
+
+test-tablebucket topic="orders_tablebucket" count="10":
+    @just up-tablebucket
+    @just create-topic-tablebucket "{{topic}}"
+    @just produce-tablebucket "{{topic}}" "{{count}}"
+    @just check-commit-tablebucket "{{topic}}"
+
+trino-sql-rest SQL:
+    {{COMPOSE_REST}} exec trino trino --execute '{{SQL}}' --output-format ALIGNED --catalog iceberg
+
+trino-sql-tablebucket SQL:
+    {{COMPOSE_TABLEBUCKET}} exec trino trino --execute '{{SQL}}' --output-format ALIGNED --catalog iceberg
+
+_wait-rest:
+    @just _wait "{{COMPOSE_REST}}"
+
+_wait-tablebucket:
+    @just _wait "{{COMPOSE_TABLEBUCKET}}"
+
+_wait compose:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Waiting for AutoMQ and Schema Registry..."
+    timeout=120
+    elapsed=0
+    until {{compose}} exec -T automq /opt/automq/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 >/dev/null 2>&1 \
+      && curl -fsS http://localhost:18081/subjects >/dev/null 2>&1; do
+      if [ "$elapsed" -ge "$timeout" ]; then
+        echo "Services were not ready within ${timeout}s"
+        exit 1
+      fi
+      sleep 2
+      elapsed=$((elapsed + 2))
+    done
+    echo "Services ready"
+
+_check-commit compose topic:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Waiting for Table Topic commit for {{topic}}..."
+    timeout=120
+    elapsed=0
+    pattern="COMMIT_RESPONSE.*code=0.*topic='{{topic}}'.*dataFiles=[1-9]"
+    until {{compose}} logs --no-color automq 2>&1 | grep -E "$pattern" >/dev/null; do
+      if [ "$elapsed" -ge "$timeout" ]; then
+        echo "No successful Table Topic commit found for {{topic}} within ${timeout}s"
+        {{compose}} logs --no-color automq 2>&1 | grep "{{topic}}" | tail -80 || true
+        exit 1
+      fi
+      sleep 2
+      elapsed=$((elapsed + 2))
+    done
+    echo "Table Topic commit succeeded for {{topic}}"

--- a/opensource-examples/table-topic/oss-tablebucket-integration/justfile
+++ b/opensource-examples/table-topic/oss-tablebucket-integration/justfile
@@ -1,5 +1,6 @@
 COMPOSE_REST := "docker compose -f docker-compose.yml -f docker-compose.automq-rest.yml"
 COMPOSE_TABLEBUCKET := "docker compose -f docker-compose.yml -f docker-compose.automq-tablebucket.yml"
+SPARK_PACKAGES := "org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.10.1,org.apache.iceberg:iceberg-aws-bundle:1.10.1"
 
 default: help
 
@@ -26,8 +27,10 @@ help:
     @echo "  produce-tablebucket [topic] [count]"
     @echo "  check-commit-rest [topic]"
     @echo "  check-commit-tablebucket [topic]"
-    @echo "  trino-sql-rest <SQL>"
-    @echo "  trino-sql-tablebucket <SQL>"
+    @echo "  spark-sql-rest <SQL>"
+    @echo "  spark-sql-tablebucket <SQL>"
+    @echo "  query-rest [topic]"
+    @echo "  query-tablebucket [topic]"
 
 up-rest:
     @test -f .env || (echo "Missing .env. Copy .env.example to .env and fill in your Aliyun settings." && exit 1)
@@ -95,11 +98,51 @@ test-tablebucket topic="orders_tablebucket" count="10":
     @just produce-tablebucket "{{topic}}" "{{count}}"
     @just check-commit-tablebucket "{{topic}}"
 
-trino-sql-rest SQL:
-    {{COMPOSE_REST}} exec trino trino --execute '{{SQL}}' --output-format ALIGNED --catalog iceberg
+spark-sql-rest SQL:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    {{COMPOSE_REST}} exec spark-iceberg bash -lc '/opt/spark/bin/spark-sql --packages {{SPARK_PACKAGES}} \
+      --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
+      --conf spark.sql.defaultCatalog=oss_tables \
+      --conf spark.sql.catalog.oss_tables=org.apache.iceberg.spark.SparkCatalog \
+      --conf spark.sql.catalog.oss_tables.type=rest \
+      --conf spark.sql.catalog.oss_tables.uri="$OSS_ICEBERG_REST_URI" \
+      --conf spark.sql.catalog.oss_tables.warehouse="$OSS_TABLE_BUCKET_ARN" \
+      --conf spark.sql.catalog.oss_tables.rest.sigv4-enabled=true \
+      --conf spark.sql.catalog.oss_tables.rest.signing-name=osstables \
+      --conf spark.sql.catalog.oss_tables.rest.signing-region="$AWS_REGION" \
+      --conf spark.sql.catalog.oss_tables.client.region="$AWS_REGION" \
+      --conf spark.sql.catalog.oss_tables.client.credentials-provider=software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider \
+      --conf spark.sql.catalog.oss_tables.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
+      --conf spark.sql.catalog.oss_tables.s3.endpoint="$OSS_ENDPOINT" \
+      --conf spark.sql.catalog.oss_tables.s3.path-style-access=false \
+      -e "{{SQL}}"'
 
-trino-sql-tablebucket SQL:
-    {{COMPOSE_TABLEBUCKET}} exec trino trino --execute '{{SQL}}' --output-format ALIGNED --catalog iceberg
+spark-sql-tablebucket SQL:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    {{COMPOSE_TABLEBUCKET}} exec spark-iceberg bash -lc '/opt/spark/bin/spark-sql --packages {{SPARK_PACKAGES}} \
+      --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
+      --conf spark.sql.defaultCatalog=oss_tables \
+      --conf spark.sql.catalog.oss_tables=org.apache.iceberg.spark.SparkCatalog \
+      --conf spark.sql.catalog.oss_tables.type=rest \
+      --conf spark.sql.catalog.oss_tables.uri="$OSS_ICEBERG_REST_URI" \
+      --conf spark.sql.catalog.oss_tables.warehouse="$OSS_TABLE_BUCKET_ARN" \
+      --conf spark.sql.catalog.oss_tables.rest.sigv4-enabled=true \
+      --conf spark.sql.catalog.oss_tables.rest.signing-name=osstables \
+      --conf spark.sql.catalog.oss_tables.rest.signing-region="$AWS_REGION" \
+      --conf spark.sql.catalog.oss_tables.client.region="$AWS_REGION" \
+      --conf spark.sql.catalog.oss_tables.client.credentials-provider=software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider \
+      --conf spark.sql.catalog.oss_tables.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
+      --conf spark.sql.catalog.oss_tables.s3.endpoint="$OSS_ENDPOINT" \
+      --conf spark.sql.catalog.oss_tables.s3.path-style-access=false \
+      -e "{{SQL}}"'
+
+query-rest topic="orders_rest" namespace="automq_it":
+    @just spark-sql-rest "SELECT * FROM oss_tables.{{namespace}}.{{topic}} LIMIT 10"
+
+query-tablebucket topic="orders_tablebucket" namespace="automq_it":
+    @just spark-sql-tablebucket "SELECT * FROM oss_tables.{{namespace}}.{{topic}} LIMIT 10"
 
 _wait-rest:
     @just _wait "{{COMPOSE_REST}}"

--- a/opensource-examples/table-topic/oss-tablebucket-integration/producer/Dockerfile
+++ b/opensource-examples/table-topic/oss-tablebucket-integration/producer/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY producer.py .

--- a/opensource-examples/table-topic/oss-tablebucket-integration/producer/producer.py
+++ b/opensource-examples/table-topic/oss-tablebucket-integration/producer/producer.py
@@ -1,0 +1,127 @@
+import argparse
+import os
+import time
+from typing import Dict
+
+from confluent_kafka import SerializingProducer
+from confluent_kafka.admin import AdminClient, NewTopic
+from confluent_kafka.schema_registry import SchemaRegistryClient
+from confluent_kafka.schema_registry.avro import AvroSerializer
+from confluent_kafka.serialization import StringSerializer
+
+
+ORDER_SCHEMA = """
+{
+  "type": "record",
+  "name": "OrderEvent",
+  "namespace": "automq.examples",
+  "fields": [
+    {"name": "order_id", "type": "long"},
+    {"name": "customer_id", "type": "string"},
+    {"name": "item", "type": "string"},
+    {"name": "quantity", "type": "int"},
+    {"name": "price", "type": "double"},
+    {"name": "event_time", "type": "long"}
+  ]
+}
+"""
+
+
+def bootstrap_servers() -> str:
+    return os.getenv("BOOTSTRAP_SERVERS", "automq:9092")
+
+
+def schema_registry_url() -> str:
+    return os.getenv("SCHEMA_REGISTRY_URL", "http://schema-registry:8081")
+
+
+def table_topic_namespace() -> str:
+    return os.getenv("TABLE_TOPIC_NAMESPACE", "automq_it")
+
+
+def create_topic(args: argparse.Namespace) -> None:
+    admin = AdminClient({"bootstrap.servers": bootstrap_servers()})
+    config = {
+        "automq.table.topic.enable": "true",
+        "automq.table.topic.commit.interval.ms": "1000",
+        "automq.table.topic.convert.value.type": "by_schema_id",
+        "automq.table.topic.transform.value.type": "flatten",
+        "automq.table.topic.namespace": args.namespace,
+        "retention.ms": "345600000",
+    }
+    topic = NewTopic(args.topic, num_partitions=args.partitions, replication_factor=1, config=config)
+    futures = admin.create_topics([topic])
+    try:
+        futures[args.topic].result(timeout=30)
+        print(f"CREATED_TOPIC={args.topic}")
+    except Exception as exc:
+        if "already exists" in str(exc).lower():
+            print(f"TOPIC_ALREADY_EXISTS={args.topic}")
+            return
+        raise
+
+
+def order_to_dict(order: Dict, _ctx) -> Dict:
+    return order
+
+
+def produce_avro(args: argparse.Namespace) -> None:
+    registry = SchemaRegistryClient({"url": schema_registry_url()})
+    avro_serializer = AvroSerializer(registry, ORDER_SCHEMA, order_to_dict)
+    producer = SerializingProducer(
+        {
+            "bootstrap.servers": bootstrap_servers(),
+            "key.serializer": StringSerializer("utf_8"),
+            "value.serializer": avro_serializer,
+            "acks": "all",
+        }
+    )
+
+    delivered = 0
+
+    def on_delivery(err, msg):
+        nonlocal delivered
+        if err is not None:
+            raise RuntimeError(f"delivery failed: {err}")
+        delivered += 1
+        print(f"ACK partition={msg.partition()} offset={msg.offset()}")
+
+    base_time = int(time.time() * 1000)
+    for i in range(args.count):
+        value = {
+            "order_id": i,
+            "customer_id": f"customer-{i % 3}",
+            "item": f"item-{i % 5}",
+            "quantity": i + 1,
+            "price": float((i + 1) * 10),
+            "event_time": base_time + i,
+        }
+        producer.produce(args.topic, key=f"order-{i}", value=value, on_delivery=on_delivery)
+        producer.poll(0)
+
+    producer.flush(30)
+    print(f"PRODUCED_TOPIC={args.topic}")
+    print(f"PRODUCED_COUNT={delivered}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="AutoMQ OSS TableBucket example producer")
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    create = subcommands.add_parser("create-topic", help="Create a Table Topic")
+    create.add_argument("--topic", required=True)
+    create.add_argument("--namespace", default=table_topic_namespace())
+    create.add_argument("--partitions", type=int, default=3)
+    create.set_defaults(func=create_topic)
+
+    produce = subcommands.add_parser("produce-avro", help="Produce Avro records")
+    produce.add_argument("--topic", required=True)
+    produce.add_argument("--count", type=int, default=10)
+    produce.set_defaults(func=produce_avro)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/opensource-examples/table-topic/oss-tablebucket-integration/producer/producer.py
+++ b/opensource-examples/table-topic/oss-tablebucket-integration/producer/producer.py
@@ -105,7 +105,7 @@ def produce_avro(args: argparse.Namespace) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="AutoMQ OSS TableBucket example producer")
+    parser = argparse.ArgumentParser(description="AutoMQ OSS Tables example producer")
     subcommands = parser.add_subparsers(dest="command", required=True)
 
     create = subcommands.add_parser("create-topic", help="Create a Table Topic")

--- a/opensource-examples/table-topic/oss-tablebucket-integration/producer/requirements.txt
+++ b/opensource-examples/table-topic/oss-tablebucket-integration/producer/requirements.txt
@@ -1,0 +1,1 @@
+confluent-kafka[schema-registry,avro]==2.8.0

--- a/opensource-examples/table-topic/playground/docker-compose.yml
+++ b/opensource-examples/table-topic/playground/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   automq:
-    image: automqinc/automq:1.6.3-rc0
+    image: automqinc/automq:1.7.0
     container_name: automq
     hostname: automq
     stop_grace_period: 1m


### PR DESCRIPTION
## Summary
- add `oss-tablebucket-integration` Table Topic example for Aliyun OSS Tables
- cover both OSS Tables REST Catalog and OSS S3 Tables Catalog modes with separate AutoMQ compose overrides
- include Schema Registry, Spark SQL, MinIO-backed AutoMQ storage, and a simple Python Avro producer
- add a Table Topic examples index and update existing Table Topic AutoMQ images to `automqinc/automq:1.7.0`

## Validation
- `docker compose -f docker-compose.yml -f docker-compose.automq-rest.yml --env-file .env.example config`
- `docker compose -f docker-compose.yml -f docker-compose.automq-tablebucket.yml --env-file .env.example config`
- `python3 -m py_compile producer/producer.py`
- `just --list`
- `git diff --check`
- local public-network smoke with real Aliyun credentials:
  - `just test-rest orders_rest_spark_20260609_1903 10`
  - `just query-rest orders_rest_spark_20260609_1903` returned 10 full rows via `SELECT * ... LIMIT 10`
  - `just test-tablebucket orders_tablebucket_spark_20260609_1914 10`
  - `just query-tablebucket orders_tablebucket_spark_20260609_1914` returned 10 full rows via `SELECT * ... LIMIT 10`

## Notes
- AutoMQ stream storage is local MinIO in this example; Table Topic Iceberg catalog/data uses Aliyun OSS Tables/OSS.
- `tablebucket` remains in command and compose names because it is the AutoMQ config value: `automq.table.topic.catalog.type=tablebucket`.
- The OSS S3 Tables Catalog mode follows the S3 Tables Catalog implementation path used by `awslabs/s3-tables-catalog`.
- Spark SQL is used for full table queries. Stock Trino can use the OSS Tables REST Catalog for catalog/schema operations, but it cannot scan OSS Tables data paths returned as `oss://` without an Aliyun OSS filesystem implementation.
- `just down` only removes local containers and volumes; it does not delete remote OSS Tables data.