### PR TITLE
fix(table-topic): support renamed fps metric

### DIFF
--- a/opensource-examples/table-topic/playground/metrics-scenario/README.md
+++ b/opensource-examples/table-topic/playground/metrics-scenario/README.md
@@ -72,7 +72,7 @@ The Table Topic Dashboard provides three views:
 |--------|-------------|
 | `kafka_tableworker_eventloop_busy_ratio_percent` | Table worker event loop busy ratio |
 | `kafka_tabletopic_delay_milliseconds` | Delay from Kafka to Iceberg by topic |
-| `kafka_tabletopic_fps_fields_per_second` | Fields per second by topic |
+| `kafka_tabletopic_fields_per_second` | Fields per second by topic |
 
 ## Troubleshooting
 

--- a/opensource-examples/table-topic/playground/metrics-scenario/grafana/provisioning/dashboards/table-topic.json
+++ b/opensource-examples/table-topic/playground/metrics-scenario/grafana/provisioning/dashboards/table-topic.json
@@ -477,7 +477,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "kafka_tabletopic_fps_fields_per_second{job=\"$cluster_id\", topic=~\"$topic\"}",
+          "expr": "{__name__=~\"kafka_tabletopic_fps_fields/s|kafka_tabletopic_fps_fields_per_second|kafka_tabletopic_fields_per_second\", job=\"$cluster_id\", topic=~\"$topic\"}",
           "legendFormat": "{{topic}}",
           "refId": "A"
         }
@@ -588,7 +588,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "kafka_tabletopic_fps_fields_per_second{job=\"$cluster_id\", topic=~\"$topic\"}",
+          "expr": "{__name__=~\"kafka_tabletopic_fps_fields/s|kafka_tabletopic_fps_fields_per_second|kafka_tabletopic_fields_per_second\", job=\"$cluster_id\", topic=~\"$topic\"}",
           "legendFormat": "{{topic}}",
           "refId": "A"
         }
@@ -720,14 +720,14 @@
       {
         "current": {},
         "datasource": { "type": "prometheus", "uid": "${datasource}" },
-        "definition": "label_values(kafka_tabletopic_fps_fields_per_second{job=\"$cluster_id\"}, topic)",
+        "definition": "label_values({__name__=~\"kafka_tabletopic_fps_fields/s|kafka_tabletopic_fps_fields_per_second|kafka_tabletopic_fields_per_second\", job=\"$cluster_id\"}, topic)",
         "hide": 0,
         "includeAll": true,
         "label": "Topic",
         "multi": true,
         "name": "topic",
         "options": [],
-        "query": { "query": "label_values(kafka_tabletopic_fps_fields_per_second{job=\"$cluster_id\"}, topic)", "refId": "StandardVariableQuery" },
+        "query": { "query": "label_values({__name__=~\"kafka_tabletopic_fps_fields/s|kafka_tabletopic_fps_fields_per_second|kafka_tabletopic_fields_per_second\", job=\"$cluster_id\"}, topic)", "refId": "StandardVariableQuery" },
         "refresh": 2,
         "sort": 1,
         "type": "query"


### PR DESCRIPTION
## Summary
- update the Table Topic metrics scenario dashboard to query legacy, interim, and final fields-per-second metric names
- document the final metric name `kafka_tabletopic_fields_per_second` in the scenario README

## Context
AutoMQ is changing the TableTopic fields-per-second metric definition to `name=kafka_tabletopic_fields` with `unit=1/s`, which exports as `kafka_tabletopic_fields_per_second`. Existing environments may still expose `kafka_tabletopic_fps_fields/s` or `kafka_tabletopic_fps_fields_per_second`, so the example dashboard keeps compatibility across all three names.

## Verification
- `jq empty opensource-examples/table-topic/playground/metrics-scenario/grafana/provisioning/dashboards/table-topic.json`
- `git diff --check -- opensource-examples/table-topic/playground/metrics-scenario/README.md opensource-examples/table-topic/playground/metrics-scenario/grafana/provisioning/dashboards/table-topic.json`