### PR TITLE
feat(gcp): add complete BYOC environment setup

### DIFF
--- a/byoc-examples/setup/kubernetes/gcp/README.md
+++ b/byoc-examples/setup/kubernetes/gcp/README.md
@@ -1,0 +1,7 @@
+# Provisioning a Kubernetes Cluster on GCP
+
+This directory provides resources for creating an AutoMQ-ready Google Kubernetes Engine (GKE) cluster.
+
+## Tools
+
+- [Terraform](./terraform/): Provisions the VPC, subnets, Cloud NAT, regional GKE cluster, and dedicated AutoMQ node pool.

--- a/byoc-examples/setup/kubernetes/gcp/README.md
+++ b/byoc-examples/setup/kubernetes/gcp/README.md
@@ -1,7 +1,7 @@
-# Provisioning a Kubernetes Cluster on GCP
+# AutoMQ BYOC Environment on GCP
 
-This directory provides resources for creating an AutoMQ-ready Google Kubernetes Engine (GKE) cluster.
+This directory provides resources for creating an AutoMQ BYOC environment on Google Cloud, including the VPC, GKE cluster, and AutoMQ Console.
 
 ## Tools
 
-- [Terraform](./terraform/): Provisions the VPC, subnets, Cloud NAT, regional GKE cluster, and dedicated AutoMQ node pool.
+- [Terraform](./terraform/): Provisions the complete GCP BYOC environment.

--- a/byoc-examples/setup/kubernetes/gcp/terraform/README.md
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/README.md
@@ -117,11 +117,11 @@ Use these values with provider `automq/automq` to create an `automq_kafka_instan
 | `console_machine_type` | Console VM machine type | `e2-standard-2` |
 | `console_ingress_source_ranges` | CIDRs allowed to access Console port 8080 | `0.0.0.0/0` |
 | `network_cidrs` | Management, workload, Pod, and Service CIDRs | See `terraform.tfvars.example` |
-| `automq_node_pool.machine_type` | AutoMQ node machine type | `n2d-standard-4` |
+| `automq_node_pool.machine_type` | AutoMQ node machine type | `n4d-standard-2` |
 | `automq_node_pool.min_size` | Minimum total nodes across the three zones | `3` |
 | `automq_node_pool.max_size` | Maximum total nodes across the three zones | `10` |
 
-To use an Arm-based Tau T2A machine, set `automq_node_pool.machine_type` to a suitable `t2a-standard-*` type and choose three zones where that type is available. Workloads scheduled to that pool must provide Arm64-compatible images.
+Supported AutoMQ node machine types are `n4d-standard-2`, `n4d-highmem-2`, `n4a-highmem-1`, `n4a-standard-2`, and `n4d-standard-4`. Confirm that the selected type is available in all three zones.
 
 When overriding `network_cidrs`, use non-overlapping IPv4 ranges that do not conflict with connected VPC, VPN, or on-premises networks.
 

--- a/byoc-examples/setup/kubernetes/gcp/terraform/README.md
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/README.md
@@ -1,0 +1,112 @@
+# AutoMQ-ready GKE cluster
+
+This Terraform example provisions a regional GKE Standard cluster and the network resources required to run AutoMQ.
+
+## Architecture
+
+The example creates:
+
+- A dedicated VPC.
+- A management subnet for a future AutoMQ Console or bastion.
+- A workload subnet with secondary ranges for GKE Pods and Services.
+- A Cloud Router and Cloud NAT covering both subnets.
+- A regional GKE Standard cluster with private nodes and a public control-plane endpoint.
+- The GKE default node pool for system workloads.
+- One dedicated AutoMQ node pool spanning three zones.
+- A firewall rule allowing the management subnet to reach AutoMQ workload nodes.
+
+The cluster uses the GKE Stable release channel, Dataplane V2, Workload Identity, GKE Metadata Server, NodeLocal DNSCache, and the GCE Persistent Disk CSI driver.
+
+This example does not create an AutoMQ Console, buckets, Cloud DNS zones, Data Plane identities, Kubernetes Service Accounts, or an AutoMQ Instance.
+
+## Prerequisites
+
+- Terraform 1.3 or later.
+- `gcloud` and `kubectl`.
+- A GCP project with billing enabled.
+- Application Default Credentials:
+
+  ```bash
+  gcloud auth application-default login
+  ```
+
+- `serviceusage.googleapis.com` enabled before running Terraform. Terraform enables `compute.googleapis.com` and `container.googleapis.com` and leaves them enabled during destroy.
+- Permissions to enable project services and create VPC, firewall, Cloud NAT, and GKE resources.
+- A usable default Compute Engine Service Account for GKE nodes.
+
+## Deploy
+
+1. Create a local variables file:
+
+   ```bash
+   cp terraform.tfvars.example terraform.tfvars
+   ```
+
+2. Set `project_id`, `region`, and exactly three zones in `terraform.tfvars`. The zones must belong to the selected region.
+
+3. Initialize and review the deployment:
+
+   ```bash
+   terraform init
+   terraform plan
+   ```
+
+4. Apply the configuration:
+
+   ```bash
+   terraform apply
+   ```
+
+5. Print and run the generated credentials command:
+
+   ```bash
+   terraform output -raw get_credentials_command
+   ```
+
+## Verify
+
+Verify the regional node placement and the dedicated AutoMQ taint:
+
+```bash
+kubectl get nodes -L topology.kubernetes.io/zone,node_type
+kubectl describe nodes | grep -A3 Taints
+```
+
+The cluster has one default node pool and one AutoMQ node pool. Each pool spans the same three zones; Terraform does not create one node pool per zone.
+
+## Configuration
+
+| Input | Description | Default |
+| --- | --- | --- |
+| `project_id` | GCP project for all resources | Required |
+| `region` | Region for the regional GKE cluster | Required |
+| `zones` | Exactly three distinct zones used by both node pools | Required |
+| `name_prefix` | Prefix for generated resource names | `automq` |
+| `network_cidrs` | Management, workload, Pod, and Service CIDRs | See `terraform.tfvars.example` |
+| `automq_node_pool.machine_type` | AutoMQ node machine type | `n2d-standard-4` |
+| `automq_node_pool.min_size` | Minimum total nodes across the three zones | `3` |
+| `automq_node_pool.max_size` | Maximum total nodes across the three zones | `10` |
+
+To use an Arm-based Tau T2A machine, set `automq_node_pool.machine_type` to a suitable `t2a-standard-*` type and choose three zones where that type is available. Workloads scheduled to that pool must provide Arm64-compatible images.
+
+When overriding `network_cidrs`, use non-overlapping IPv4 ranges that do not conflict with connected VPC, VPN, or on-premises networks.
+
+## Outputs
+
+The root module outputs the canonical GKE, VPC, and subnet resource IDs, the AutoMQ node pool name, the Workload Identity pool, and a `gcloud` credentials command. It does not output access tokens, kubeconfig contents, the cluster CA, or the default Compute Engine Service Account.
+
+## Network access
+
+GKE nodes use private IP addresses and reach external services through Cloud NAT. The GKE control-plane endpoint remains public and uses GKE authentication and authorization; Master Authorized Networks is not enabled in this example.
+
+The root firewall rule allows the management subnet to reach AutoMQ workload nodes on the ports used by the AutoMQ deployment. Add separate, narrowly scoped rules for Kafka clients or other external subnets.
+
+## Cleanup
+
+Delete any AutoMQ resources using the cluster before destroying the infrastructure:
+
+```bash
+terraform destroy
+```
+
+`deletion_protection` is disabled so the example can be destroyed through Terraform.

--- a/byoc-examples/setup/kubernetes/gcp/terraform/README.md
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/README.md
@@ -9,7 +9,7 @@ The example creates:
 - A dedicated VPC.
 - A management subnet for the AutoMQ Console.
 - A workload subnet with secondary ranges for GKE Pods and Services.
-- A Cloud Router and Cloud NAT covering both subnets.
+- A Cloud Router and Cloud NAT for private GKE node egress.
 - A regional GKE Standard cluster with private nodes and a public control-plane endpoint.
 - The GKE default node pool for system workloads.
 - One dedicated AutoMQ node pool spanning three zones.
@@ -72,6 +72,8 @@ This example does not create an AutoMQ Instance. After the environment is ready,
    terraform output -raw get_credentials_command
    ```
 
+   Run the command printed by Terraform.
+
 ## Verify
 
 Verify the Console endpoint:
@@ -121,7 +123,7 @@ Use these values with provider `automq/automq` to create an `automq_kafka_instan
 | `automq_node_pool.min_size` | Minimum total nodes across the three zones | `3` |
 | `automq_node_pool.max_size` | Maximum total nodes across the three zones | `10` |
 
-Supported AutoMQ node machine types are `n4d-standard-2`, `n4d-highmem-2`, `n4a-highmem-1`, `n4a-standard-2`, and `n4d-standard-4`. Confirm that the selected type is available in all three zones.
+Supported AutoMQ node machine types are `n4d-standard-2`, `n4d-highmem-2`, `n4a-highmem-1`, `n4a-standard-2`, and `n4d-standard-4`. Confirm that the selected type is available in all three zones. The AutoMQ node pool uses `hyperdisk-balanced` boot disks, as required by these N4 machine families.
 
 When overriding `network_cidrs`, use non-overlapping IPv4 ranges that do not conflict with connected VPC, VPN, or on-premises networks.
 

--- a/byoc-examples/setup/kubernetes/gcp/terraform/README.md
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/README.md
@@ -1,38 +1,41 @@
-# AutoMQ-ready GKE cluster
+# AutoMQ BYOC environment on GCP
 
-This Terraform example provisions a regional GKE Standard cluster and the network resources required to run AutoMQ.
+This Terraform example provisions a complete AutoMQ BYOC environment on GCP: a dedicated VPC, a regional GKE Standard cluster, and an AutoMQ Console VM.
 
 ## Architecture
 
 The example creates:
 
 - A dedicated VPC.
-- A management subnet for a future AutoMQ Console or bastion.
+- A management subnet for the AutoMQ Console.
 - A workload subnet with secondary ranges for GKE Pods and Services.
 - A Cloud Router and Cloud NAT covering both subnets.
 - A regional GKE Standard cluster with private nodes and a public control-plane endpoint.
 - The GKE default node pool for system workloads.
 - One dedicated AutoMQ node pool spanning three zones.
-- A firewall rule allowing the management subnet to reach AutoMQ workload nodes.
+- An AutoMQ Console VM with a static public endpoint and persistent data disk.
+- A Console service account and its GCP control-plane permissions.
+- Firewall rules for Console access and Console-to-AutoMQ traffic.
 
 The cluster uses the GKE Stable release channel, Dataplane V2, Workload Identity, GKE Metadata Server, NodeLocal DNSCache, and the GCE Persistent Disk CSI driver.
 
-This example does not create an AutoMQ Console, buckets, Cloud DNS zones, Data Plane identities, Kubernetes Service Accounts, or an AutoMQ Instance.
+This example does not create an AutoMQ Instance. After the environment is ready, use the Console or the `automq/automq` Terraform provider with the output endpoint and access keys. The Console creates the environment's Ops Bucket during bootstrap and each Instance's Data Bucket and DNS Zone when the Instance is created.
 
 ## Prerequisites
 
 - Terraform 1.3 or later.
 - `gcloud` and `kubectl`.
 - A GCP project with billing enabled.
+- A GCP BYOC installation configuration from AutoMQ containing the base64 `CONFIG` value and Console image.
 - Application Default Credentials:
 
   ```bash
   gcloud auth application-default login
   ```
 
-- `serviceusage.googleapis.com` enabled before running Terraform. Terraform enables `compute.googleapis.com` and `container.googleapis.com` and leaves them enabled during destroy.
-- Permissions to enable project services and create VPC, firewall, Cloud NAT, and GKE resources.
-- A usable default Compute Engine Service Account for GKE nodes.
+- `serviceusage.googleapis.com` enabled before running Terraform. Terraform enables the remaining Compute, GKE, DNS, IAM, Storage, and Resource Manager APIs and leaves them enabled during destroy.
+- Permissions to enable project services and create VPC, GKE, Compute Engine, IAM, Cloud DNS, and GCS resources.
+- A usable default Compute Engine service account for GKE nodes.
 
 ## Deploy
 
@@ -42,22 +45,28 @@ This example does not create an AutoMQ Console, buckets, Cloud DNS zones, Data P
    cp terraform.tfvars.example terraform.tfvars
    ```
 
-2. Set `project_id`, `region`, and exactly three zones in `terraform.tfvars`. The zones must belong to the selected region.
+2. Set `project_id`, `region`, exactly three zones, `automq_config`, and `automq_console_image` in `terraform.tfvars`.
 
-3. Initialize and review the deployment:
+3. If the Console image is private, also set all fields in `automq_console_registry`.
+
+4. Initialize, review, and apply:
 
    ```bash
    terraform init
    terraform plan
-   ```
-
-4. Apply the configuration:
-
-   ```bash
    terraform apply
    ```
 
-5. Print and run the generated credentials command:
+5. Open the Console:
+
+   ```bash
+   terraform output -raw console_endpoint
+   terraform output -raw console_initial_password
+   ```
+
+   The initial username is `admin`.
+
+6. Configure `kubectl`:
 
    ```bash
    terraform output -raw get_credentials_command
@@ -65,7 +74,13 @@ This example does not create an AutoMQ Console, buckets, Cloud DNS zones, Data P
 
 ## Verify
 
-Verify the regional node placement and the dedicated AutoMQ taint:
+Verify the Console endpoint:
+
+```bash
+curl -I "$(terraform output -raw console_endpoint)"
+```
+
+Verify regional node placement and the dedicated AutoMQ taint:
 
 ```bash
 kubectl get nodes -L topology.kubernetes.io/zone,node_type
@@ -74,14 +89,33 @@ kubectl describe nodes | grep -A3 Taints
 
 The cluster has one default node pool and one AutoMQ node pool. Each pool spans the same three zones; Terraform does not create one node pool per zone.
 
+## AutoMQ provider
+
+The Console module generates an initial access key pair for automation. Read the values without placing them in a committed `tfvars` file:
+
+```bash
+terraform output -raw console_endpoint
+terraform output -raw console_initial_access_key
+terraform output -raw console_initial_secret_key
+terraform output -raw automq_environment_id
+```
+
+Use these values with provider `automq/automq` to create an `automq_kafka_instance`. The GKE cluster ID and workload subnet ID are available as `gke_cluster_id` and `workload_subnet_id`.
+
 ## Configuration
 
 | Input | Description | Default |
 | --- | --- | --- |
 | `project_id` | GCP project for all resources | Required |
-| `region` | Region for the regional GKE cluster | Required |
+| `region` | Region for the environment | Required |
 | `zones` | Exactly three distinct zones used by both node pools | Required |
 | `name_prefix` | Prefix for generated resource names | `automq` |
+| `automq_config` | Base64 `CONFIG` value containing the BYOC environment settings | Required |
+| `automq_console_image` | GCP Console container image from AutoMQ | Required |
+| `automq_home_endpoint` | AutoMQ Cloud endpoint | `https://console.automq.cloud` |
+| `automq_console_registry` | Optional private registry credentials | Empty |
+| `console_machine_type` | Console VM machine type | `e2-standard-2` |
+| `console_ingress_source_ranges` | CIDRs allowed to access Console port 8080 | `0.0.0.0/0` |
 | `network_cidrs` | Management, workload, Pod, and Service CIDRs | See `terraform.tfvars.example` |
 | `automq_node_pool.machine_type` | AutoMQ node machine type | `n2d-standard-4` |
 | `automq_node_pool.min_size` | Minimum total nodes across the three zones | `3` |
@@ -91,22 +125,20 @@ To use an Arm-based Tau T2A machine, set `automq_node_pool.machine_type` to a su
 
 When overriding `network_cidrs`, use non-overlapping IPv4 ranges that do not conflict with connected VPC, VPN, or on-premises networks.
 
-## Outputs
-
-The root module outputs the canonical GKE, VPC, and subnet resource IDs, the AutoMQ node pool name, the Workload Identity pool, and a `gcloud` credentials command. It does not output access tokens, kubeconfig contents, the cluster CA, or the default Compute Engine Service Account.
-
-## Network access
+## Security notes
 
 GKE nodes use private IP addresses and reach external services through Cloud NAT. The GKE control-plane endpoint remains public and uses GKE authentication and authorization; Master Authorized Networks is not enabled in this example.
 
-The root firewall rule allows the management subnet to reach AutoMQ workload nodes on the ports used by the AutoMQ deployment. Add separate, narrowly scoped rules for Kafka clients or other external subnets.
+The Console endpoint is public so the example is easy to access. Restrict `console_ingress_source_ranges` to trusted public CIDRs. The management subnet can reach AutoMQ workload nodes only on the required ports; add separate, narrowly scoped rules for Kafka clients.
+
+The Console service account uses broad control-plane permissions so it can manage GKE, IAM, DNS, and instance resources. The bootstrap client secret, registry password, and generated Console credentials are stored in Terraform state and GCE instance metadata. Protect the state and use a hardened secret-delivery and IAM design for production.
 
 ## Cleanup
 
-Delete any AutoMQ resources using the cluster before destroying the infrastructure:
+Delete AutoMQ Instances using the cluster before destroying the environment:
 
 ```bash
 terraform destroy
 ```
 
-`deletion_protection` is disabled so the example can be destroyed through Terraform.
+The Console-created Ops Bucket is outside Terraform state; delete it separately after the environment is no longer used.

--- a/byoc-examples/setup/kubernetes/gcp/terraform/console/main.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/console/main.tf
@@ -1,0 +1,170 @@
+locals {
+  resource_prefix = "${var.name_prefix}-console"
+
+  service_account_id = trim(substr("${local.resource_prefix}-sa", 0, 30), "-")
+
+  labels = {
+    automq_vendor = "automq"
+    component     = "console"
+  }
+
+  runtime_roles = toset([
+    "roles/container.admin",
+    "roles/compute.networkViewer",
+    "roles/dns.admin",
+    "roles/iam.roleAdmin",
+    "roles/iam.serviceAccountAdmin",
+    "roles/resourcemanager.projectIamAdmin",
+    "roles/storage.admin",
+  ])
+}
+
+resource "google_service_account" "console" {
+  project      = var.project_id
+  account_id   = local.service_account_id
+  display_name = "AutoMQ BYOC Console"
+}
+
+resource "google_project_iam_member" "console" {
+  for_each = local.runtime_roles
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.console.email}"
+}
+
+resource "google_project_iam_custom_role" "dns_iam_admin" {
+  project     = var.project_id
+  role_id     = "automqByocConsoleDnsZoneIamPolicyAdmin"
+  title       = "AutoMQ Console DNS Zone IAM Policy Admin"
+  description = "Allows the AutoMQ Console to update IAM policy on Cloud DNS managed zones"
+  permissions = [
+    "dns.managedZones.getIamPolicy",
+    "dns.managedZones.setIamPolicy",
+  ]
+}
+
+resource "google_project_iam_member" "console_dns_iam_admin" {
+  project = var.project_id
+  role    = google_project_iam_custom_role.dns_iam_admin.name
+  member  = "serviceAccount:${google_service_account.console.email}"
+}
+
+resource "google_compute_address" "console" {
+  project = var.project_id
+  name    = "${local.resource_prefix}-ip"
+  region  = var.region
+}
+
+resource "google_compute_disk" "console" {
+  project = var.project_id
+  name    = "${local.resource_prefix}-data"
+  zone    = var.zone
+  type    = "pd-ssd"
+  size    = 20
+  labels  = local.labels
+}
+
+resource "google_compute_firewall" "console" {
+  project = var.project_id
+  name    = "${local.resource_prefix}-ingress"
+  network = var.network_id
+
+  direction     = "INGRESS"
+  source_ranges = var.ingress_source_ranges
+
+  allow {
+    protocol = "tcp"
+    ports    = ["8080"]
+  }
+
+  target_service_accounts = [google_service_account.console.email]
+}
+
+resource "random_password" "initial_password" {
+  length  = 24
+  special = false
+}
+
+resource "random_password" "access_key" {
+  length  = 16
+  special = false
+}
+
+resource "random_password" "secret_key" {
+  length  = 32
+  special = false
+}
+
+resource "random_id" "console_bootstrap" {
+  byte_length = 1
+
+  keepers = {
+    configuration = sha256(jsonencode({
+      console_image = var.console_image
+      config        = var.config
+      home_endpoint = var.home_endpoint
+      registry      = var.registry
+    }))
+  }
+}
+
+resource "google_compute_instance" "console" {
+  project      = var.project_id
+  name         = local.resource_prefix
+  machine_type = var.machine_type
+  zone         = var.zone
+  labels       = local.labels
+
+  boot_disk {
+    initialize_params {
+      image = "projects/debian-cloud/global/images/family/debian-12"
+      size  = 30
+      type  = "pd-balanced"
+    }
+  }
+
+  attached_disk {
+    source      = google_compute_disk.console.id
+    device_name = "automq-console-data"
+    mode        = "READ_WRITE"
+  }
+
+  network_interface {
+    subnetwork = var.management_subnet_id
+
+    access_config {
+      nat_ip = google_compute_address.console.address
+    }
+  }
+
+  metadata_startup_script = templatefile("${path.module}/startup.sh.tpl", {
+    console_image_b64     = base64encode(var.console_image)
+    config_b64            = base64encode(var.config)
+    home_endpoint_b64     = base64encode(var.home_endpoint)
+    initial_password_b64  = base64encode(random_password.initial_password.result)
+    access_key_b64        = base64encode(random_password.access_key.result)
+    secret_key_b64        = base64encode(random_password.secret_key.result)
+    service_account_b64   = base64encode(google_service_account.console.email)
+    registry_server_b64   = base64encode(var.registry.server)
+    registry_username_b64 = base64encode(var.registry.username)
+    registry_password_b64 = base64encode(var.registry.password)
+  })
+
+  service_account {
+    email  = google_service_account.console.email
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
+
+  lifecycle {
+    replace_triggered_by = [random_id.console_bootstrap]
+  }
+
+  allow_stopping_for_update = true
+
+  depends_on = [
+    google_compute_firewall.console,
+    google_project_iam_member.console,
+    google_project_iam_member.console_dns_iam_admin,
+  ]
+}

--- a/byoc-examples/setup/kubernetes/gcp/terraform/console/outputs.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/console/outputs.tf
@@ -3,11 +3,6 @@ output "endpoint" {
   value       = "http://${google_compute_address.console.address}:8080"
 }
 
-output "initial_username" {
-  description = "Initial AutoMQ Console username."
-  value       = "admin"
-}
-
 output "initial_password" {
   description = "Initial AutoMQ Console password."
   value       = random_password.initial_password.result
@@ -26,9 +21,9 @@ output "initial_secret_key" {
   sensitive   = true
 }
 
-output "service_account" {
-  description = "Full resource name of the Console service account."
-  value       = google_service_account.console.name
+output "service_account_email" {
+  description = "Email address of the Console service account."
+  value       = google_service_account.console.email
 }
 
 output "vm_name" {

--- a/byoc-examples/setup/kubernetes/gcp/terraform/console/outputs.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/console/outputs.tf
@@ -1,0 +1,37 @@
+output "endpoint" {
+  description = "Public AutoMQ Console endpoint."
+  value       = "http://${google_compute_address.console.address}:8080"
+}
+
+output "initial_username" {
+  description = "Initial AutoMQ Console username."
+  value       = "admin"
+}
+
+output "initial_password" {
+  description = "Initial AutoMQ Console password."
+  value       = random_password.initial_password.result
+  sensitive   = true
+}
+
+output "initial_access_key" {
+  description = "Access key ID for the AutoMQ Terraform provider."
+  value       = random_password.access_key.result
+  sensitive   = true
+}
+
+output "initial_secret_key" {
+  description = "Secret key for the AutoMQ Terraform provider."
+  value       = random_password.secret_key.result
+  sensitive   = true
+}
+
+output "service_account" {
+  description = "Full resource name of the Console service account."
+  value       = google_service_account.console.name
+}
+
+output "vm_name" {
+  description = "AutoMQ Console VM name."
+  value       = google_compute_instance.console.name
+}

--- a/byoc-examples/setup/kubernetes/gcp/terraform/console/startup.sh.tpl
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/console/startup.sh.tpl
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+decode() {
+  printf '%s' "$1" | base64 -d
+}
+
+CONSOLE_IMAGE="$(decode '${console_image_b64}')"
+CONFIG="$(decode '${config_b64}')"
+HOME_ENDPOINT="$(decode '${home_endpoint_b64}')"
+INITIAL_PASSWORD="$(decode '${initial_password_b64}')"
+ACCESS_KEY="$(decode '${access_key_b64}')"
+SECRET_KEY="$(decode '${secret_key_b64}')"
+SERVICE_ACCOUNT="$(decode '${service_account_b64}')"
+REGISTRY_SERVER="$(decode '${registry_server_b64}')"
+REGISTRY_USERNAME="$(decode '${registry_username_b64}')"
+REGISTRY_PASSWORD="$(decode '${registry_password_b64}')"
+
+if ! command -v docker >/dev/null 2>&1; then
+  apt-get update
+  apt-get install -y ca-certificates docker.io
+fi
+systemctl enable --now docker
+
+DATA_DEVICE="/dev/disk/by-id/google-automq-console-data"
+while [ ! -e "$DATA_DEVICE" ]; do
+  sleep 1
+done
+
+if ! blkid "$DATA_DEVICE"; then
+  mkfs.ext4 -F "$DATA_DEVICE"
+fi
+
+mkdir -p /data
+if ! mountpoint -q /data; then
+  mount "$DATA_DEVICE" /data
+fi
+grep -q " /data " /etc/fstab || echo "$DATA_DEVICE /data ext4 defaults,nofail 0 2" >> /etc/fstab
+
+if docker container inspect automq-console >/dev/null 2>&1; then
+  docker start automq-console >/dev/null
+  exit 0
+fi
+
+if [ -n "$REGISTRY_SERVER" ]; then
+  printf '%s' "$REGISTRY_PASSWORD" | docker login \
+    --username "$REGISTRY_USERNAME" \
+    --password-stdin \
+    "$REGISTRY_SERVER"
+fi
+
+docker run -d \
+  --name automq-console \
+  --restart unless-stopped \
+  --net=host \
+  -v /data:/root \
+  -e CONFIG="$CONFIG" \
+  -e CLOUD_PROVIDER=gcp \
+  -e HOME_ENDPOINT="$HOME_ENDPOINT" \
+  -e CONSOLE_INITIAL_USER=admin \
+  -e CONSOLE_INITIAL_PASSWORD="$INITIAL_PASSWORD" \
+  -e CONSOLE_INITIAL_ACCESS_KEY="$ACCESS_KEY" \
+  -e CONSOLE_INITIAL_SECRET_KEY="$SECRET_KEY" \
+  -e CONSOLE_PORT=8080 \
+  -e GCP_SERVICE_ACCOUNT="$SERVICE_ACCOUNT" \
+  "$CONSOLE_IMAGE"

--- a/byoc-examples/setup/kubernetes/gcp/terraform/console/variables.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/console/variables.tf
@@ -1,0 +1,65 @@
+variable "project_id" {
+  description = "GCP project where the Console resources are created."
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for regional Console resources."
+  type        = string
+}
+
+variable "zone" {
+  description = "GCP zone for the Console VM and data disk."
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "Prefix used for Console resource names."
+  type        = string
+}
+
+variable "network_id" {
+  description = "Canonical ID of the VPC used by the Console firewall."
+  type        = string
+}
+
+variable "management_subnet_id" {
+  description = "Canonical ID of the management subnet used by the Console."
+  type        = string
+}
+
+variable "config" {
+  description = "Base64-encoded AutoMQ BYOC CONFIG value."
+  type        = string
+  sensitive   = true
+}
+
+variable "console_image" {
+  description = "AutoMQ GCP Console container image."
+  type        = string
+}
+
+variable "home_endpoint" {
+  description = "AutoMQ Cloud endpoint used by the Console."
+  type        = string
+}
+
+variable "machine_type" {
+  description = "GCE machine type used by the Console VM."
+  type        = string
+}
+
+variable "ingress_source_ranges" {
+  description = "IPv4 CIDR ranges allowed to access the Console."
+  type        = list(string)
+}
+
+variable "registry" {
+  description = "Optional private container registry credentials."
+  type = object({
+    server   = string
+    username = string
+    password = string
+  })
+  sensitive = true
+}

--- a/byoc-examples/setup/kubernetes/gcp/terraform/gke/main.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/gke/main.tf
@@ -1,0 +1,102 @@
+locals {
+  automq_network_tag = "${var.name_prefix}-automq-workload"
+}
+
+resource "google_container_cluster" "main" {
+  project                  = var.project_id
+  name                     = "${var.name_prefix}-gke"
+  location                 = var.region
+  node_locations           = var.zones
+  network                  = var.network_id
+  subnetwork               = var.workload_subnet_id
+  initial_node_count       = 1
+  deletion_protection      = false
+  networking_mode          = "VPC_NATIVE"
+  enable_l4_ilb_subsetting = true
+
+  release_channel {
+    channel = "STABLE"
+  }
+
+  addons_config {
+    dns_cache_config {
+      enabled = true
+    }
+
+    gce_persistent_disk_csi_driver_config {
+      enabled = true
+    }
+  }
+
+  datapath_provider = "ADVANCED_DATAPATH"
+
+  workload_identity_config {
+    workload_pool = "${var.project_id}.svc.id.goog"
+  }
+
+  ip_allocation_policy {
+    cluster_secondary_range_name  = var.pod_secondary_range_name
+    services_secondary_range_name = var.service_secondary_range_name
+  }
+
+  private_cluster_config {
+    enable_private_nodes    = true
+    enable_private_endpoint = false
+  }
+
+  node_config {
+    machine_type = "n2d-standard-4"
+    oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = alltrue([for zone in var.zones : startswith(zone, "${var.region}-")])
+      error_message = "Every zone must belong to the selected region."
+    }
+  }
+}
+
+resource "google_container_node_pool" "automq" {
+  project            = var.project_id
+  name               = "${var.name_prefix}-automq"
+  location           = var.region
+  node_locations     = var.zones
+  cluster            = google_container_cluster.main.name
+  initial_node_count = 1
+
+  node_config {
+    machine_type = var.automq_node_pool.machine_type
+    oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+    tags         = [local.automq_network_tag]
+
+    labels = {
+      node_type = "automq"
+    }
+
+    taint {
+      key    = "dedicated"
+      value  = "automq"
+      effect = "NO_SCHEDULE"
+    }
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+  }
+
+  autoscaling {
+    total_min_node_count = var.automq_node_pool.min_size
+    total_max_node_count = var.automq_node_pool.max_size
+    location_policy      = "BALANCED"
+  }
+
+  management {
+    auto_repair  = false
+    auto_upgrade = true
+  }
+}

--- a/byoc-examples/setup/kubernetes/gcp/terraform/gke/main.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/gke/main.tf
@@ -71,6 +71,7 @@ resource "google_container_node_pool" "automq" {
 
   node_config {
     machine_type = var.automq_node_pool.machine_type
+    disk_type    = "hyperdisk-balanced"
     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
     tags         = [local.automq_network_tag]
 

--- a/byoc-examples/setup/kubernetes/gcp/terraform/gke/outputs.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/gke/outputs.tf
@@ -1,0 +1,24 @@
+output "cluster_id" {
+  description = "Canonical GKE cluster resource ID."
+  value       = google_container_cluster.main.id
+}
+
+output "cluster_name" {
+  description = "GKE cluster name."
+  value       = google_container_cluster.main.name
+}
+
+output "automq_node_pool_name" {
+  description = "Name of the dedicated AutoMQ workload node pool."
+  value       = google_container_node_pool.automq.name
+}
+
+output "automq_network_tag" {
+  description = "Network tag applied to AutoMQ workload nodes."
+  value       = local.automq_network_tag
+}
+
+output "workload_identity_pool" {
+  description = "Workload Identity pool configured on the GKE cluster."
+  value       = google_container_cluster.main.workload_identity_config[0].workload_pool
+}

--- a/byoc-examples/setup/kubernetes/gcp/terraform/gke/variables.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/gke/variables.tf
@@ -1,0 +1,48 @@
+variable "project_id" {
+  description = "GCP project where the GKE cluster is created."
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for the regional GKE cluster."
+  type        = string
+}
+
+variable "zones" {
+  description = "Zones used by the default and AutoMQ node pools."
+  type        = list(string)
+}
+
+variable "name_prefix" {
+  description = "Prefix used to derive GKE resource names."
+  type        = string
+}
+
+variable "network_id" {
+  description = "Canonical VPC resource ID."
+  type        = string
+}
+
+variable "workload_subnet_id" {
+  description = "Canonical subnet resource ID used by GKE nodes."
+  type        = string
+}
+
+variable "pod_secondary_range_name" {
+  description = "Secondary subnet range used for GKE Pods."
+  type        = string
+}
+
+variable "service_secondary_range_name" {
+  description = "Secondary subnet range used for GKE Services."
+  type        = string
+}
+
+variable "automq_node_pool" {
+  description = "Capacity settings for the dedicated AutoMQ workload node pool."
+  type = object({
+    machine_type = string
+    min_size     = number
+    max_size     = number
+  })
+}

--- a/byoc-examples/setup/kubernetes/gcp/terraform/main.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/main.tf
@@ -9,18 +9,6 @@ locals {
     "iam.googleapis.com",
     "storage.googleapis.com",
   ])
-
-  automq_ports = [
-    "8081",
-    "8083",
-    "9090",
-    "9092",
-    "9093",
-    "9102",
-    "9103",
-    "9112",
-    "9113",
-  ]
 }
 
 resource "google_project_service" "required" {
@@ -74,9 +62,8 @@ module "console" {
   machine_type          = var.console_machine_type
   ingress_source_ranges = var.console_ingress_source_ranges
   registry              = var.automq_console_registry
-  depends_on = [
-    google_project_service.required,
-  ]
+
+  depends_on = [google_project_service.required]
 }
 
 resource "google_compute_firewall" "management_to_automq" {
@@ -90,6 +77,6 @@ resource "google_compute_firewall" "management_to_automq" {
 
   allow {
     protocol = "tcp"
-    ports    = local.automq_ports
+    ports    = ["8081", "8083", "9090", "9092", "9093", "9102", "9103", "9112", "9113"]
   }
 }

--- a/byoc-examples/setup/kubernetes/gcp/terraform/main.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/main.tf
@@ -1,7 +1,13 @@
 locals {
+  automq_environment_id = nonsensitive(jsondecode(base64decode(var.automq_config)).environmentId)
+
   required_services = toset([
+    "cloudresourcemanager.googleapis.com",
     "compute.googleapis.com",
     "container.googleapis.com",
+    "dns.googleapis.com",
+    "iam.googleapis.com",
+    "storage.googleapis.com",
   ])
 
   automq_ports = [
@@ -50,6 +56,27 @@ module "gke" {
   automq_node_pool             = var.automq_node_pool
 
   depends_on = [google_project_service.required]
+}
+
+module "console" {
+  source = "./console"
+
+  project_id           = var.project_id
+  region               = var.region
+  zone                 = var.zones[0]
+  name_prefix          = var.name_prefix
+  network_id           = module.network.vpc_id
+  management_subnet_id = module.network.management_subnet_id
+
+  config                = var.automq_config
+  console_image         = var.automq_console_image
+  home_endpoint         = var.automq_home_endpoint
+  machine_type          = var.console_machine_type
+  ingress_source_ranges = var.console_ingress_source_ranges
+  registry              = var.automq_console_registry
+  depends_on = [
+    google_project_service.required,
+  ]
 }
 
 resource "google_compute_firewall" "management_to_automq" {

--- a/byoc-examples/setup/kubernetes/gcp/terraform/main.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/main.tf
@@ -1,0 +1,68 @@
+locals {
+  required_services = toset([
+    "compute.googleapis.com",
+    "container.googleapis.com",
+  ])
+
+  automq_ports = [
+    "8081",
+    "8083",
+    "9090",
+    "9092",
+    "9093",
+    "9102",
+    "9103",
+    "9112",
+    "9113",
+  ]
+}
+
+resource "google_project_service" "required" {
+  for_each = local.required_services
+
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
+
+module "network" {
+  source = "./network"
+
+  project_id    = var.project_id
+  region        = var.region
+  name_prefix   = var.name_prefix
+  network_cidrs = var.network_cidrs
+
+  depends_on = [google_project_service.required]
+}
+
+module "gke" {
+  source = "./gke"
+
+  project_id                   = var.project_id
+  region                       = var.region
+  zones                        = var.zones
+  name_prefix                  = var.name_prefix
+  network_id                   = module.network.vpc_id
+  workload_subnet_id           = module.network.workload_subnet_id
+  pod_secondary_range_name     = module.network.pod_secondary_range_name
+  service_secondary_range_name = module.network.service_secondary_range_name
+  automq_node_pool             = var.automq_node_pool
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_compute_firewall" "management_to_automq" {
+  project = var.project_id
+  name    = "${var.name_prefix}-management-to-automq"
+  network = module.network.vpc_id
+
+  direction     = "INGRESS"
+  source_ranges = [module.network.management_subnet_cidr]
+  target_tags   = [module.gke.automq_network_tag]
+
+  allow {
+    protocol = "tcp"
+    ports    = local.automq_ports
+  }
+}

--- a/byoc-examples/setup/kubernetes/gcp/terraform/network/main.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/network/main.tf
@@ -55,11 +55,6 @@ resource "google_compute_router_nat" "main" {
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
 
   subnetwork {
-    name                    = google_compute_subnetwork.management.id
-    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
-  }
-
-  subnetwork {
     name                    = google_compute_subnetwork.workload.id
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
   }

--- a/byoc-examples/setup/kubernetes/gcp/terraform/network/main.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/network/main.tf
@@ -1,0 +1,66 @@
+locals {
+  pod_secondary_range_name     = "${var.name_prefix}-pods"
+  service_secondary_range_name = "${var.name_prefix}-services"
+}
+
+resource "google_compute_network" "main" {
+  project                 = var.project_id
+  name                    = "${var.name_prefix}-vpc"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "management" {
+  project                  = var.project_id
+  name                     = "${var.name_prefix}-management"
+  region                   = var.region
+  network                  = google_compute_network.main.id
+  ip_cidr_range            = var.network_cidrs.management
+  private_ip_google_access = true
+  stack_type               = "IPV4_ONLY"
+}
+
+resource "google_compute_subnetwork" "workload" {
+  project                  = var.project_id
+  name                     = "${var.name_prefix}-workload"
+  region                   = var.region
+  network                  = google_compute_network.main.id
+  ip_cidr_range            = var.network_cidrs.workload
+  private_ip_google_access = true
+  stack_type               = "IPV4_ONLY"
+
+  secondary_ip_range {
+    range_name    = local.pod_secondary_range_name
+    ip_cidr_range = var.network_cidrs.pods
+  }
+
+  secondary_ip_range {
+    range_name    = local.service_secondary_range_name
+    ip_cidr_range = var.network_cidrs.services
+  }
+}
+
+resource "google_compute_router" "main" {
+  project = var.project_id
+  name    = "${var.name_prefix}-router"
+  region  = var.region
+  network = google_compute_network.main.id
+}
+
+resource "google_compute_router_nat" "main" {
+  project                            = var.project_id
+  name                               = "${var.name_prefix}-nat"
+  region                             = var.region
+  router                             = google_compute_router.main.name
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+
+  subnetwork {
+    name                    = google_compute_subnetwork.management.id
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  subnetwork {
+    name                    = google_compute_subnetwork.workload.id
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+}

--- a/byoc-examples/setup/kubernetes/gcp/terraform/network/outputs.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/network/outputs.tf
@@ -18,11 +18,6 @@ output "workload_subnet_id" {
   value       = google_compute_subnetwork.workload.id
 }
 
-output "workload_subnet_cidr" {
-  description = "Primary CIDR of the GKE workload subnet."
-  value       = google_compute_subnetwork.workload.ip_cidr_range
-}
-
 output "pod_secondary_range_name" {
   description = "Name of the secondary range used for GKE Pods."
   value       = local.pod_secondary_range_name

--- a/byoc-examples/setup/kubernetes/gcp/terraform/network/outputs.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/network/outputs.tf
@@ -1,0 +1,34 @@
+output "vpc_id" {
+  description = "Canonical VPC resource ID."
+  value       = google_compute_network.main.id
+}
+
+output "management_subnet_id" {
+  description = "Canonical management subnet resource ID."
+  value       = google_compute_subnetwork.management.id
+}
+
+output "management_subnet_cidr" {
+  description = "Primary CIDR of the management subnet."
+  value       = google_compute_subnetwork.management.ip_cidr_range
+}
+
+output "workload_subnet_id" {
+  description = "Canonical GKE workload subnet resource ID."
+  value       = google_compute_subnetwork.workload.id
+}
+
+output "workload_subnet_cidr" {
+  description = "Primary CIDR of the GKE workload subnet."
+  value       = google_compute_subnetwork.workload.ip_cidr_range
+}
+
+output "pod_secondary_range_name" {
+  description = "Name of the secondary range used for GKE Pods."
+  value       = local.pod_secondary_range_name
+}
+
+output "service_secondary_range_name" {
+  description = "Name of the secondary range used for GKE Services."
+  value       = local.service_secondary_range_name
+}

--- a/byoc-examples/setup/kubernetes/gcp/terraform/network/variables.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/network/variables.tf
@@ -1,0 +1,24 @@
+variable "project_id" {
+  description = "GCP project where network resources are created."
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for the subnets and Cloud NAT."
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "Prefix used to derive network resource names."
+  type        = string
+}
+
+variable "network_cidrs" {
+  description = "CIDR ranges for management, workload, Pods, and Services."
+  type = object({
+    management = string
+    workload   = string
+    pods       = string
+    services   = string
+  })
+}

--- a/byoc-examples/setup/kubernetes/gcp/terraform/outputs.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/outputs.tf
@@ -58,11 +58,6 @@ output "console_endpoint" {
   value       = module.console.endpoint
 }
 
-output "console_initial_username" {
-  description = "Initial username for the AutoMQ BYOC Console."
-  value       = module.console.initial_username
-}
-
 output "console_initial_password" {
   description = "Initial password for the AutoMQ BYOC Console."
   value       = module.console.initial_password
@@ -81,9 +76,9 @@ output "console_initial_secret_key" {
   sensitive   = true
 }
 
-output "console_service_account" {
-  description = "Service account used by the AutoMQ Console VM."
-  value       = module.console.service_account
+output "console_service_account_email" {
+  description = "Email address of the service account used by the AutoMQ Console VM."
+  value       = module.console.service_account_email
 }
 
 output "automq_environment_id" {

--- a/byoc-examples/setup/kubernetes/gcp/terraform/outputs.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/outputs.tf
@@ -52,3 +52,46 @@ output "get_credentials_command" {
   description = "Command that configures kubectl credentials for the GKE cluster."
   value       = "gcloud container clusters get-credentials ${module.gke.cluster_name} --region ${var.region} --project ${var.project_id}"
 }
+
+output "console_endpoint" {
+  description = "Public endpoint for the AutoMQ BYOC Console."
+  value       = module.console.endpoint
+}
+
+output "console_initial_username" {
+  description = "Initial username for the AutoMQ BYOC Console."
+  value       = module.console.initial_username
+}
+
+output "console_initial_password" {
+  description = "Initial password for the AutoMQ BYOC Console."
+  value       = module.console.initial_password
+  sensitive   = true
+}
+
+output "console_initial_access_key" {
+  description = "Access key ID for the AutoMQ Terraform provider."
+  value       = module.console.initial_access_key
+  sensitive   = true
+}
+
+output "console_initial_secret_key" {
+  description = "Secret key for the AutoMQ Terraform provider."
+  value       = module.console.initial_secret_key
+  sensitive   = true
+}
+
+output "console_service_account" {
+  description = "Service account used by the AutoMQ Console VM."
+  value       = module.console.service_account
+}
+
+output "automq_environment_id" {
+  description = "AutoMQ BYOC environment ID used by the Console and Terraform provider."
+  value       = local.automq_environment_id
+}
+
+output "console_vm_name" {
+  description = "AutoMQ Console VM name."
+  value       = module.console.vm_name
+}

--- a/byoc-examples/setup/kubernetes/gcp/terraform/outputs.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/outputs.tf
@@ -1,0 +1,54 @@
+output "project_id" {
+  description = "GCP project containing the provisioned resources."
+  value       = var.project_id
+}
+
+output "region" {
+  description = "GCP region containing the regional GKE cluster."
+  value       = var.region
+}
+
+output "zones" {
+  description = "Zones used by the GKE node pools."
+  value       = var.zones
+}
+
+output "gke_cluster_id" {
+  description = "Canonical GKE cluster resource ID."
+  value       = module.gke.cluster_id
+}
+
+output "gke_cluster_name" {
+  description = "GKE cluster name."
+  value       = module.gke.cluster_name
+}
+
+output "automq_node_pool_name" {
+  description = "Name of the dedicated AutoMQ workload node pool."
+  value       = module.gke.automq_node_pool_name
+}
+
+output "vpc_id" {
+  description = "Canonical VPC resource ID."
+  value       = module.network.vpc_id
+}
+
+output "management_subnet_id" {
+  description = "Canonical management subnet resource ID."
+  value       = module.network.management_subnet_id
+}
+
+output "workload_subnet_id" {
+  description = "Canonical GKE workload subnet resource ID."
+  value       = module.network.workload_subnet_id
+}
+
+output "workload_identity_pool" {
+  description = "Workload Identity pool configured on the GKE cluster."
+  value       = module.gke.workload_identity_pool
+}
+
+output "get_credentials_command" {
+  description = "Command that configures kubectl credentials for the GKE cluster."
+  value       = "gcloud container clusters get-credentials ${module.gke.cluster_name} --region ${var.region} --project ${var.project_id}"
+}

--- a/byoc-examples/setup/kubernetes/gcp/terraform/providers.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/providers.tf
@@ -1,0 +1,4 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/byoc-examples/setup/kubernetes/gcp/terraform/terraform.tfvars.example
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/terraform.tfvars.example
@@ -3,6 +3,19 @@ region      = "us-central1"
 zones       = ["us-central1-a", "us-central1-b", "us-central1-c"]
 name_prefix = "automq"
 
+automq_config        = "replace-with-base64-CONFIG-value"
+automq_console_image = "replace-me"
+
+# Restrict this to the public IP range used to access the Console.
+console_ingress_source_ranges = ["0.0.0.0/0"]
+
+# Set all three values only when automq_console_image is private.
+automq_console_registry = {
+  server   = ""
+  username = ""
+  password = ""
+}
+
 network_cidrs = {
   management = "10.10.0.0/24"
   workload   = "10.20.0.0/20"

--- a/byoc-examples/setup/kubernetes/gcp/terraform/terraform.tfvars.example
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/terraform.tfvars.example
@@ -1,0 +1,17 @@
+project_id  = "your-gcp-project-id"
+region      = "us-central1"
+zones       = ["us-central1-a", "us-central1-b", "us-central1-c"]
+name_prefix = "automq"
+
+network_cidrs = {
+  management = "10.10.0.0/24"
+  workload   = "10.20.0.0/20"
+  pods       = "10.30.0.0/16"
+  services   = "10.40.0.0/20"
+}
+
+automq_node_pool = {
+  machine_type = "n2d-standard-4"
+  min_size     = 3
+  max_size     = 10
+}

--- a/byoc-examples/setup/kubernetes/gcp/terraform/terraform.tfvars.example
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/terraform.tfvars.example
@@ -24,7 +24,7 @@ network_cidrs = {
 }
 
 automq_node_pool = {
-  machine_type = "n2d-standard-4"
+  machine_type = "n4d-standard-2"
   min_size     = 3
   max_size     = 10
 }

--- a/byoc-examples/setup/kubernetes/gcp/terraform/variables.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/variables.tf
@@ -1,0 +1,87 @@
+variable "project_id" {
+  description = "GCP project where the network and GKE cluster are created."
+  type        = string
+
+  validation {
+    condition     = trimspace(var.project_id) != ""
+    error_message = "project_id must not be empty."
+  }
+}
+
+variable "region" {
+  description = "GCP region for the regional GKE cluster."
+  type        = string
+
+  validation {
+    condition     = trimspace(var.region) != ""
+    error_message = "region must not be empty."
+  }
+}
+
+variable "zones" {
+  description = "Three zones in the selected region used by the default and AutoMQ node pools."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.zones) == 3 && length(distinct(var.zones)) == 3 && alltrue([for zone in var.zones : trimspace(zone) != ""])
+    error_message = "zones must contain exactly three distinct, non-empty zones."
+  }
+}
+
+variable "name_prefix" {
+  description = "Prefix used to derive the names of all resources."
+  type        = string
+  default     = "automq"
+
+  validation {
+    condition     = can(regex("^[a-z]([-a-z0-9]*[a-z0-9])?$", var.name_prefix)) && length(var.name_prefix) <= 33
+    error_message = "name_prefix must use lowercase letters, numbers, or hyphens, start with a letter, end with a letter or number, and contain at most 33 characters."
+  }
+}
+
+variable "network_cidrs" {
+  description = "CIDR ranges for the management subnet, workload subnet, GKE Pods, and GKE Services."
+  type = object({
+    management = string
+    workload   = string
+    pods       = string
+    services   = string
+  })
+  default = {
+    management = "10.10.0.0/24"
+    workload   = "10.20.0.0/20"
+    pods       = "10.30.0.0/16"
+    services   = "10.40.0.0/20"
+  }
+
+  validation {
+    condition = alltrue([
+      for cidr in values(var.network_cidrs) :
+      can(cidrhost(cidr, 0)) && can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}/", cidr))
+    ])
+    error_message = "Every network_cidrs value must be a valid IPv4 CIDR."
+  }
+}
+
+variable "automq_node_pool" {
+  description = "Capacity settings for the dedicated AutoMQ workload node pool."
+  type = object({
+    machine_type = string
+    min_size     = number
+    max_size     = number
+  })
+  default = {
+    machine_type = "n2d-standard-4"
+    min_size     = 3
+    max_size     = 10
+  }
+
+  validation {
+    condition = (
+      trimspace(var.automq_node_pool.machine_type) != "" &&
+      var.automq_node_pool.min_size >= 3 &&
+      var.automq_node_pool.max_size >= var.automq_node_pool.min_size
+    )
+    error_message = "automq_node_pool requires a non-empty machine_type, min_size of at least 3, and max_size greater than or equal to min_size."
+  }
+}

--- a/byoc-examples/setup/kubernetes/gcp/terraform/variables.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/variables.tf
@@ -85,3 +85,94 @@ variable "automq_node_pool" {
     error_message = "automq_node_pool requires a non-empty machine_type, min_size of at least 3, and max_size greater than or equal to min_size."
   }
 }
+
+variable "automq_config" {
+  description = "Base64-encoded AutoMQ BYOC CONFIG value from the GCP installation configuration."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition = can(alltrue([
+      for value in [
+        jsondecode(base64decode(var.automq_config)).environmentId,
+        jsondecode(base64decode(var.automq_config)).clientId,
+        jsondecode(base64decode(var.automq_config)).clientSecret,
+        jsondecode(base64decode(var.automq_config)).region,
+        jsondecode(base64decode(var.automq_config)).opsBucket.bucketName,
+      ] : trimspace(value) != ""
+    ]))
+    error_message = "automq_config must be valid base64 JSON containing environmentId, clientId, clientSecret, region, and opsBucket.bucketName."
+  }
+}
+
+variable "automq_console_image" {
+  description = "AutoMQ GCP Console container image from the installation configuration."
+  type        = string
+
+  validation {
+    condition     = trimspace(var.automq_console_image) != ""
+    error_message = "automq_console_image must not be empty."
+  }
+}
+
+variable "automq_home_endpoint" {
+  description = "AutoMQ Cloud endpoint used by the BYOC Console."
+  type        = string
+  default     = "https://console.automq.cloud"
+
+  validation {
+    condition     = can(regex("^https?://", var.automq_home_endpoint))
+    error_message = "automq_home_endpoint must be an HTTP or HTTPS URL."
+  }
+}
+
+variable "automq_console_registry" {
+  description = "Optional credentials used to pull a private Console container image."
+  type = object({
+    server   = string
+    username = string
+    password = string
+  })
+  default = {
+    server   = ""
+    username = ""
+    password = ""
+  }
+  sensitive = true
+
+  validation {
+    condition = (
+      alltrue([for value in values(var.automq_console_registry) : trimspace(value) == ""]) ||
+      alltrue([for value in values(var.automq_console_registry) : trimspace(value) != ""])
+    )
+    error_message = "automq_console_registry fields must either all be empty or all be set."
+  }
+}
+
+variable "console_machine_type" {
+  description = "GCE machine type used by the AutoMQ Console VM."
+  type        = string
+  default     = "e2-standard-2"
+
+  validation {
+    condition     = trimspace(var.console_machine_type) != ""
+    error_message = "console_machine_type must not be empty."
+  }
+}
+
+variable "console_ingress_source_ranges" {
+  description = "IPv4 CIDR ranges allowed to access the AutoMQ Console on TCP port 8080."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+
+  validation {
+    condition = (
+      length(var.console_ingress_source_ranges) > 0 &&
+      alltrue([
+        for cidr in var.console_ingress_source_ranges :
+        can(cidrhost(cidr, 0)) && can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}/", cidr))
+      ])
+    )
+    error_message = "console_ingress_source_ranges must contain at least one valid IPv4 CIDR."
+  }
+}

--- a/byoc-examples/setup/kubernetes/gcp/terraform/variables.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/variables.tf
@@ -71,18 +71,24 @@ variable "automq_node_pool" {
     max_size     = number
   })
   default = {
-    machine_type = "n2d-standard-4"
+    machine_type = "n4d-standard-2"
     min_size     = 3
     max_size     = 10
   }
 
   validation {
     condition = (
-      trimspace(var.automq_node_pool.machine_type) != "" &&
+      contains([
+        "n4d-standard-2",
+        "n4d-highmem-2",
+        "n4a-highmem-1",
+        "n4a-standard-2",
+        "n4d-standard-4",
+      ], var.automq_node_pool.machine_type) &&
       var.automq_node_pool.min_size >= 3 &&
       var.automq_node_pool.max_size >= var.automq_node_pool.min_size
     )
-    error_message = "automq_node_pool requires a non-empty machine_type, min_size of at least 3, and max_size greater than or equal to min_size."
+    error_message = "automq_node_pool.machine_type must be an AutoMQ-supported GCP machine type; min_size must be at least 3; max_size must be greater than or equal to min_size."
   }
 }
 

--- a/byoc-examples/setup/kubernetes/gcp/terraform/versions.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/byoc-examples/setup/kubernetes/gcp/terraform/versions.tf
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- add byoc-examples/setup/kubernetes/gcp/terraform as a focused GKE provisioning example
  - create a dedicated VPC, management/workload subnets, Pod/Service secondary ranges, and workload-only Cloud NAT
  - create a regional GKE Standard cluster with private nodes and one default system pool
  - create one dedicated AutoMQ node pool spanning three zones
  - restrict the AutoMQ pool to Console-supported GCP machine types, defaulting to n4d-standard-2 with a hyperdisk-balanced boot disk
  - provide a management-subnet-to-AutoMQ firewall example for the required workload ports
- add byoc-examples/setup/gcp/terraform as an independent AutoMQ BYOC Console example
  - deploy the Console VM, persistent disk, public TCP/8080 endpoint, runtime GSA, project IAM, and DNS IAM custom role
  - accept an existing VPC and management subnet through canonical GCP resource IDs
  - accept the installation-script base64 CONFIG as one sensitive input and pass it through unchanged
  - generate Console login and AutoMQ Terraform provider credentials
- keep GKE and Console in separate Terraform roots, state, and lifecycle
- document the handoff from GKE outputs (vpc_id, management_subnet_id) to Console inputs
- let the Console create the environment Ops Bucket during bootstrap and each Instance Data Bucket and DNS Zone during Instance creation

The Console implementation follows the core resource and bootstrap contract from automq-playground/gcp/console, while leaving out Playground-only Shared VPC, Rig, Marathon, remote upgrade orchestration, and pre-created Instance resources.

## Validation

- terraform fmt -check -recursive
- terraform validate in both Terraform roots
- Console startup template checked with bash -n
- migrated the existing real environment state from one combined state into independent Kubernetes (10 resources) and Console (22 resources) states
- verified the split state address sets are disjoint and their union exactly matches all 32 original resource addresses
- assigned distinct state lineages to the two roots
- verified both roots produce No changes against the deployed automq-public environment
- verified six GKE nodes Ready across three zones, private node IPs, AutoMQ labels/taints, total autoscaling, and Cloud NAT egress from an AutoMQ-scheduled smoke Pod
- verified all three AutoMQ pool nodes use n4d-standard-2 and hyperdisk-balanced boot disks
- verified the Console image digest sha256:682dd14bdbed5d271806134ec05a48d027c7df15c8de48013995fcbe5714427b
- verified the Console container is stable with restart count 0 and the public endpoint returns the expected login redirect
- removed and restored all eight Console GSA project IAM memberships to validate the direct binding check

Closes #18
