### PR TITLE
feat(gcp): add AutoMQ instance example

### DIFF
--- a/byoc-examples/setup/gcp/README.md
+++ b/byoc-examples/setup/gcp/README.md
@@ -10,3 +10,7 @@ existing GCP VPC and subnet.
 
 To create a suitable GKE cluster and network first, use the
 [GKE Terraform example](../kubernetes/gcp/terraform/).
+
+After the GKE and Console setups are ready, the optional
+[AutoMQ Instance example](./automq-cluster/) shows how to create a three-node,
+usage-based S3WAL Instance with the `automq/automq` provider.

--- a/byoc-examples/setup/gcp/automq-cluster/README.md
+++ b/byoc-examples/setup/gcp/automq-cluster/README.md
@@ -1,0 +1,82 @@
+# Create an AutoMQ Instance on GCP
+
+This optional Terraform example uses the `automq/automq` provider to create one
+AutoMQ Instance after the GKE and Console setups are ready. It is a standalone
+reference with its own Terraform state and is not called by either setup.
+
+The example creates:
+
+- A GKE Standard deployment across three zones.
+- Three usage-based AutoMQ nodes.
+- S3WAL object-storage-backed WAL.
+- Control Plane-managed Data Bucket, DNS Zone, and Instance Identity.
+- Anonymous plaintext access inside the VPC.
+
+It reuses the dedicated AutoMQ node pool from the GKE setup through its
+`node_type=automq` label and `dedicated=automq:NoSchedule` taint. It does not
+create another node pool.
+
+## Prerequisites
+
+- AutoMQ Control Plane 8.3.8 or later.
+- Terraform 1.3 or later.
+- A completed [GKE setup](../../kubernetes/gcp/terraform/).
+- A completed [Console setup](../terraform/).
+
+## Configure
+
+Get the GKE values:
+
+```bash
+terraform output -raw gke_cluster_id
+terraform output -raw workload_subnet_id
+terraform output -json zones
+```
+
+Get the Console values:
+
+```bash
+terraform output -raw console_endpoint
+terraform output -raw console_initial_access_key
+terraform output -raw console_initial_secret_key
+terraform output -raw automq_environment_id
+```
+
+Protect the Console credentials and Terraform state. Both contain sensitive
+values.
+
+Edit the example values in `terraform/main.tf`, then export the Console
+credentials:
+
+```bash
+export AUTOMQ_BYOC_ENDPOINT="<console-endpoint>"
+export AUTOMQ_BYOC_ACCESS_KEY="<console-access-key>"
+export AUTOMQ_BYOC_SECRET_KEY="<console-secret-key>"
+```
+
+## Create
+
+```bash
+cd terraform
+terraform init
+terraform plan
+terraform apply
+```
+
+The managed resources are intentionally omitted from `compute_specs`. The
+Control Plane creates and manages the Instance Data Bucket, DNS Zone, and cloud
+identity.
+
+## Outputs
+
+```bash
+terraform output -raw instance_id
+terraform output instance_status
+terraform output -json instance_endpoints
+```
+
+## Cleanup
+
+```bash
+terraform destroy
+```

--- a/byoc-examples/setup/gcp/automq-cluster/terraform/main.tf
+++ b/byoc-examples/setup/gcp/automq-cluster/terraform/main.tf
@@ -1,0 +1,71 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    automq = {
+      source  = "automq/automq"
+      version = "~> 0.4.4"
+    }
+  }
+}
+
+locals {
+  schedule_spec = trimspace(<<-YAML
+    nodeSelector:
+      node_type: automq
+    tolerations:
+      - key: dedicated
+        operator: Equal
+        value: automq
+        effect: NoSchedule
+  YAML
+  )
+}
+
+provider "automq" {}
+
+resource "automq_kafka_instance" "example" {
+  environment_id = "<environment-id>"
+  name           = "automq-gcp-example"
+  description    = "Three-node S3WAL example on GKE"
+  version        = "<supported-automq-version>"
+
+  compute_specs = {
+    pricing_mode        = "UsageBased"
+    reserved_node_count = 3
+    deploy_type         = "K8S"
+
+    networks = [
+      for zone in ["us-central1-a", "us-central1-b", "us-central1-c"] : {
+        zone    = zone
+        subnets = []
+      }
+    ]
+
+    kubernetes_cluster_id            = "projects/<project-id>/locations/us-central1/clusters/automq-gke"
+    instance_types                   = ["n4d-standard-2"]
+    kubernetes_load_balancer_subnets = ["projects/<project-id>/regions/us-central1/subnetworks/automq-workload"]
+    schedule_spec                    = local.schedule_spec
+  }
+
+  features = {
+    wal_mode = "S3WAL"
+
+    security = {
+      authentication_methods   = ["anonymous"]
+      transit_encryption_modes = ["plaintext"]
+    }
+  }
+}
+
+output "instance_id" {
+  value = automq_kafka_instance.example.id
+}
+
+output "instance_status" {
+  value = automq_kafka_instance.example.status
+}
+
+output "instance_endpoints" {
+  value = automq_kafka_instance.example.endpoints
+}

--- a/byoc-examples/setup/gcp/terraform/README.md
+++ b/byoc-examples/setup/gcp/terraform/README.md
@@ -81,7 +81,8 @@ terraform output -raw automq_environment_id
 ```
 
 Use these values with provider `automq/automq` to create an
-`automq_kafka_instance`.
+`automq_kafka_instance`. See the standalone
+[AutoMQ Instance example](../automq-cluster/) for a minimal GKE configuration.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

- add a standalone GCP AutoMQ Instance Terraform example alongside the Console setup
- create a three-node, three-zone, usage-based S3WAL Instance on GKE Standard
- use Control Plane-managed Data Bucket, DNS Zone, and Instance Identity with plaintext access
- keep the example literal and independent from the GKE and Console Terraform states

## Validation

- `terraform fmt -check -recursive byoc-examples/setup/gcp`
- `terraform validate` in `byoc-examples/setup/gcp/automq-cluster/terraform`
- `terraform plan -refresh=false` with dummy provider credentials
