### PR TITLE
docs(gcp): clarify provider and network guidance

### DIFF
--- a/byoc-examples/setup/gcp/automq-cluster/README.md
+++ b/byoc-examples/setup/gcp/automq-cluster/README.md
@@ -37,21 +37,20 @@ Get the Console values:
 
 ```bash
 terraform output -raw console_endpoint
-terraform output -raw console_initial_access_key
-terraform output -raw console_initial_secret_key
 terraform output -raw automq_environment_id
 ```
 
-Protect the Console credentials and Terraform state. Both contain sensitive
-values.
+Sign in to the Console, create a Service Account and an Access Key in the UI,
+and protect the generated credentials. See
+[Service Accounts](https://docs.automq.com/automq-cloud/manage-identities-and-access/service-accounts).
 
-Edit the example values in `terraform/main.tf`, then export the Console
-credentials:
+Edit the example values in `terraform/main.tf`, then export the provider
+endpoint and Service Account credentials:
 
 ```bash
 export AUTOMQ_BYOC_ENDPOINT="<console-endpoint>"
-export AUTOMQ_BYOC_ACCESS_KEY="<console-access-key>"
-export AUTOMQ_BYOC_SECRET_KEY="<console-secret-key>"
+export AUTOMQ_BYOC_ACCESS_KEY="<service-account-access-key>"
+export AUTOMQ_BYOC_SECRET_KEY="<service-account-secret-key>"
 ```
 
 ## Create

--- a/byoc-examples/setup/gcp/terraform/README.md
+++ b/byoc-examples/setup/gcp/terraform/README.md
@@ -10,7 +10,7 @@ and Kubernetes infrastructure have independent Terraform state and lifecycle.
 - A Console service account and its GCP control-plane permissions.
 - A custom role for Cloud DNS managed-zone IAM policy operations.
 - A firewall rule for public Console access on TCP port 8080.
-- Generated initial Console and AutoMQ Terraform provider credentials.
+- Generated bootstrap credentials used during Console initialization.
 
 The Console creates the environment Ops Bucket during bootstrap and creates
 each Instance's Data Bucket and DNS Zone when the Instance is created.
@@ -71,17 +71,17 @@ existing VPC and subnet.
 
 ## AutoMQ Provider
 
-The Console generates an initial access key pair for automation:
+Get the provider endpoint and environment ID from Terraform:
 
 ```bash
 terraform output -raw console_endpoint
-terraform output -raw console_initial_access_key
-terraform output -raw console_initial_secret_key
 terraform output -raw automq_environment_id
 ```
 
-Use these values with provider `automq/automq` to create an
-`automq_kafka_instance`. See the standalone
+Sign in to the Console, create a Service Account and an Access Key in the UI,
+then configure provider `automq/automq` with that Access Key. See
+[Service Accounts](https://docs.automq.com/automq-cloud/manage-identities-and-access/service-accounts)
+and the standalone
 [AutoMQ Instance example](../automq-cluster/) for a minimal GKE configuration.
 
 ## Configuration

--- a/byoc-examples/setup/kubernetes/gcp/terraform/README.md
+++ b/byoc-examples/setup/kubernetes/gcp/terraform/README.md
@@ -109,6 +109,9 @@ Supported AutoMQ node machine types are `n4d-standard-2`, `n4d-highmem-2`,
 `n4a-highmem-1`, `n4a-standard-2`, and `n4d-standard-4`. Confirm that the
 selected type is available in all three zones. The AutoMQ node pool uses
 `hyperdisk-balanced` boot disks, as required by these N4 machine families.
+When an Instance is created, AutoMQ also creates the
+`automq-disk-gcp-pd-balanced` StorageClass for persistent volumes. The name is
+retained for compatibility; its disk type is `hyperdisk-balanced`.
 
 When overriding `network_cidrs`, use non-overlapping IPv4 ranges that do not
 conflict with connected VPC, VPN, or on-premises networks.
@@ -119,8 +122,16 @@ GKE nodes use private IP addresses and reach external services through Cloud
 NAT. The GKE control-plane endpoint remains public and uses GKE authentication
 and authorization; Master Authorized Networks is not enabled in this example.
 
-The management subnet can reach AutoMQ workload nodes only on the required
-ports. Add separate, narrowly scoped rules for Kafka clients in other subnets.
+The management and workload subnets share one VPC, so GCP provides routes
+between them. The Console uses the management subnet. Private GKE nodes use the
+workload subnet, with secondary ranges for Pods and Services, and Cloud NAT
+provides their outbound Internet access. The example firewall allows the
+management subnet to reach tagged AutoMQ nodes on the required control and
+Kafka ports.
+
+For Kafka clients in another subnet, add a narrowly scoped ingress firewall
+rule from the client CIDR to the same AutoMQ node tag. Open only the listener
+ports those clients require, typically TCP `9092` for plaintext Kafka.
 
 ## Cleanup
 


### PR DESCRIPTION
## Summary

- direct users to create AutoMQ Provider credentials through a Console Service Account
- explain the management/workload subnet layout and scoped Kafka client firewall rules
- clarify that the legacy `automq-disk-gcp-pd-balanced` StorageClass name provisions `hyperdisk-balanced` disks

## Validation

- `git diff --check`
- verified the Service Account documentation link returns HTTP 200
- verified Provider environment variable names against `terraform-provider-automq`