### PR TITLE
chore(aws): update EKS example to Kubernetes 1.36

### DIFF
--- a/byoc-examples/setup/kubernetes/aws/terraform/eks-addons/helm.tf
+++ b/byoc-examples/setup/kubernetes/aws/terraform/eks-addons/helm.tf
@@ -8,6 +8,7 @@ resource "helm_release" "autoscaler" {
   namespace  = "kube-system"
   repository = "https://kubernetes.github.io/autoscaler"
   chart      = "cluster-autoscaler"
+  version    = "9.59.0"
 
   dependency_update = true
   values = [
@@ -21,6 +22,13 @@ resource "helm_release" "autoscaler" {
       }
     )
   ]
+
+  # Keep Cluster Autoscaler on the same minor version as the EKS control plane.
+  # Chart 9.59.0 defaults to v1.35.0 while the v1.36 image is already released.
+  set {
+    name  = "image.tag"
+    value = "v1.36.1"
+  }
 
   timeout = 600
 

--- a/byoc-examples/setup/kubernetes/aws/terraform/eks/main.tf
+++ b/byoc-examples/setup/kubernetes/aws/terraform/eks/main.tf
@@ -6,7 +6,7 @@ module "eks" {
   version = "21.2.0"
 
   name               = local.cluster_name
-  kubernetes_version = "1.32"
+  kubernetes_version = "1.36"
 
   endpoint_public_access                   = true
   enable_cluster_creator_admin_permissions = true


### PR DESCRIPTION
## Summary

- update the standalone AWS EKS Terraform example from Kubernetes 1.32 to 1.36
- pin the Cluster Autoscaler Helm chart to 9.59.0
- select `cluster-autoscaler:v1.36.1` so the autoscaler minor version matches the EKS control plane

## Scope

This PR only updates the example on a new branch based on the latest `main`.

It does not modify the existing `chore/k8s-version` branch used by Playground AWS Global Env. Playground remains pinned to that branch at its restored commit `914a110`.

## Validation

- `terraform fmt -check -recursive`
- `git diff --check`
- `terraform init -backend=false && terraform validate` in both `eks-addons` and `eks`
- rendered chart 9.59.0 and verified `registry.k8s.io/autoscaling/cluster-autoscaler:v1.36.1`
- verified the `v1.36.1` multi-arch image manifest is published

No live EKS apply was run.
